### PR TITLE
Feature/pair status and layout

### DIFF
--- a/src/components/CustomTextField/index.tsx
+++ b/src/components/CustomTextField/index.tsx
@@ -3,6 +3,7 @@ import ThemeTextField from './index.styles';
 import { ICustomTextField } from './interfaces';
 
 function CustomTextField({
+  className,
   disabled,
   error,
   fullWidth,
@@ -19,6 +20,7 @@ function CustomTextField({
 }: ICustomTextField): React.ReactElement {
   return (
     <ThemeTextField
+      className={className}
       disabled={disabled}
       error={error}
       fullWidth={fullWidth}

--- a/src/components/CustomTextField/interfaces/index.ts
+++ b/src/components/CustomTextField/interfaces/index.ts
@@ -13,6 +13,7 @@ type TInputProps = {
 };
 
 export interface ICustomTextField {
+  className?: string;
   disabled?: boolean;
   error?: boolean;
   fullWidth?: boolean;

--- a/src/components/Navbar/DrawerList/index.styles.ts
+++ b/src/components/Navbar/DrawerList/index.styles.ts
@@ -1,0 +1,25 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import { TEXT_LIGHT_COLOR } from '../../../definitions/constants/themeStylesConfigs';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    list: {
+      width: 256,
+    },
+    title: {
+      color: TEXT_LIGHT_COLOR,
+      fontSize: '0.875rem',
+      paddingTop: theme.spacing(2),
+      paddingLeft: 0,
+      paddingRight: 0,
+      paddingBottom: 0,
+    },
+    menuLinks: {
+      padding: theme.spacing(2),
+      marginLeft: theme.spacing(1),
+      marginRight: theme.spacing(1),
+    },
+  })
+);
+
+export default useStyles;

--- a/src/components/Navbar/DrawerList/index.tsx
+++ b/src/components/Navbar/DrawerList/index.tsx
@@ -1,41 +1,20 @@
 import React from 'react';
+import Box from '@material-ui/core/Box';
 import Divider from '@material-ui/core/Divider';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import menuItems from '../../../definitions/constants/menuItemsConfigs';
-import { TEXT_LIGHT_COLOR } from '../../../definitions/constants/themeStylesConfigs';
 import { ReactComponent as SecondaryLogoIcon } from '../../../images/SecondaryLogoIcon.svg';
 import { IDrawerList } from '../interfaces/NavbarInterfaces';
 import NavbarHeader from '../NavbarHeader';
+import useStyles from './index.styles';
 import MenuItems from './MenuItems';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    list: {
-      width: 256,
-    },
-    title: {
-      color: TEXT_LIGHT_COLOR,
-      fontSize: 14,
-      paddingTop: theme.spacing(2),
-      paddingLeft: 0,
-      paddingRight: 0,
-      paddingBottom: 0,
-    },
-    menuLinks: {
-      padding: theme.spacing(2),
-      marginLeft: theme.spacing(1),
-      marginRight: theme.spacing(1),
-    },
-  })
-);
 
 function DrawerList({ toggleDrawer }: IDrawerList): React.ReactElement {
   const classes = useStyles();
   const { samplePos, terminals } = menuItems;
 
   return (
-    <div className={classes.list} role="presentation" onClick={toggleDrawer} onKeyDown={toggleDrawer}>
+    <Box className={classes.list} onClick={toggleDrawer} onKeyDown={toggleDrawer}>
       <NavbarHeader handleToggleDrawer={toggleDrawer} icon={<SecondaryLogoIcon />} />
       <div className={classes.menuLinks}>
         <Typography className={classes.title}>Sample POS</Typography>
@@ -44,7 +23,7 @@ function DrawerList({ toggleDrawer }: IDrawerList): React.ReactElement {
         <Typography className={classes.title}>Terminals</Typography>
         <MenuItems menuItems={terminals} />
       </div>
-    </div>
+    </Box>
   );
 }
 

--- a/src/components/Navbar/NavbarHeader/index.styles.ts
+++ b/src/components/Navbar/NavbarHeader/index.styles.ts
@@ -1,0 +1,11 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    menuButton: {
+      marginRight: theme.spacing(2),
+    },
+  })
+);
+
+export default useStyles;

--- a/src/components/Navbar/NavbarHeader/index.tsx
+++ b/src/components/Navbar/NavbarHeader/index.tsx
@@ -1,17 +1,9 @@
 import React from 'react';
 import IconButton from '@material-ui/core/IconButton';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Toolbar from '@material-ui/core/Toolbar';
 import MenuIcon from '@material-ui/icons/Menu';
 import { INavbarHeader } from '../interfaces/NavbarInterfaces';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    menuButton: {
-      marginRight: theme.spacing(2),
-    },
-  })
-);
+import useStyles from './index.styles';
 
 function NavbarHeader({ handleToggleDrawer, icon }: INavbarHeader): React.ReactElement {
   const classes = useStyles();
@@ -24,6 +16,8 @@ function NavbarHeader({ handleToggleDrawer, icon }: INavbarHeader): React.ReactE
         color="inherit"
         edge="start"
         onClick={handleToggleDrawer}
+        name="menuIcon"
+        aria-label="menu"
       >
         <MenuIcon />
       </IconButton>

--- a/src/components/PairPage/FlowPanel/index.styles.ts
+++ b/src/components/PairPage/FlowPanel/index.styles.ts
@@ -1,0 +1,32 @@
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import { drawerWidth } from '../../../definitions/constants/commonConfigs';
+
+export default makeStyles((theme: Theme) =>
+  createStyles({
+    drawer: {
+      width: `${drawerWidth}%`,
+      flexShrink: 0,
+    },
+    drawerPaper: {
+      width: `${drawerWidth}%`,
+      borderLeft: 'none',
+      background: 'transparent',
+      display: 'flex',
+      justifyContent: 'center',
+    },
+    flowBoxWrapper: {
+      height: '100%',
+      maxHeight: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      padding: theme.spacing(10, 0, 4, 0),
+    },
+    flowBox: {
+      background: theme.palette.common.white,
+      width: '100%',
+      height: '100%',
+      overflowY: 'scroll', // handle flow status longer messages
+      padding: theme.spacing(2),
+    },
+  })
+);

--- a/src/components/PairPage/FlowPanel/index.tsx
+++ b/src/components/PairPage/FlowPanel/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import Drawer from '@material-ui/core/Drawer';
+import Typography from '@material-ui/core/Typography';
+import useStyles from './index.styles';
+import { FlowPanelInterface } from './interfaces';
+
+export default function FlowPanel({ flow }: FlowPanelInterface): React.ReactElement {
+  const classes = useStyles();
+
+  return (
+    <Drawer
+      className={classes.drawer}
+      variant="persistent"
+      anchor="right"
+      open={flow}
+      classes={{
+        paper: classes.drawerPaper,
+      }}
+    >
+      <Box className={classes.flowBoxWrapper}>
+        <Box className={classes.flowBox}>
+          <Typography variant="h6" component="h1">
+            Flow
+          </Typography>
+        </Box>
+      </Box>
+    </Drawer>
+  );
+}

--- a/src/components/PairPage/FlowPanel/interfaces/index.tsx
+++ b/src/components/PairPage/FlowPanel/interfaces/index.tsx
@@ -1,0 +1,3 @@
+export interface FlowPanelInterface {
+  flow: boolean;
+}

--- a/src/components/PairPage/PairForm/index.styles.ts
+++ b/src/components/PairPage/PairForm/index.styles.ts
@@ -3,7 +3,13 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     formContainer: {
-      padding: theme.spacing(0, 12, 0, 0),
+      paddingRight: theme.spacing(8),
+      '& .MuiInputBase-input': {
+        textOverflow: 'ellipsis',
+      },
+    },
+    pairForm: {
+      marginBottom: -theme.spacing(2),
     },
     mainTitle: {
       marginBottom: theme.spacing(1),
@@ -37,9 +43,33 @@ const useStyles = makeStyles((theme: Theme) =>
     columnSpace: {
       paddingRight: theme.spacing(2),
     },
+    configurationLabel: {
+      width: '100%',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    },
     configurationField: {
       '&:hover .MuiOutlinedInput-notchedOutline': {
         borderColor: theme.palette.info.main,
+      },
+    },
+    [theme.breakpoints.between(960, 1024)]: {
+      formContainer: {
+        paddingRight: theme.spacing(4),
+      },
+    },
+    [theme.breakpoints.between(600, 959)]: {
+      formContainer: {
+        paddingRight: theme.spacing(2),
+      },
+    },
+    [theme.breakpoints.down(600)]: {
+      columnSpace: {
+        paddingRight: 0,
+      },
+      paymentProvider: {
+        paddingRight: theme.spacing(2),
       },
     },
   })

--- a/src/components/PairPage/PairForm/index.tsx
+++ b/src/components/PairPage/PairForm/index.tsx
@@ -16,7 +16,9 @@ import {
   TEXT_FORM_VALIDATION_POS_ID_TEXTFIELD,
   TEXT_FORM_VALIDATION_PROVIDER_TEXTFIELD,
   TEXT_FORM_VALIDATION_SERIAL_NUMBER_TEXTFIELD,
+  TEXT_STATUS_PAIRING,
 } from '../../../definitions/constants/commonConfigs';
+import { useAppSelector } from '../../../redux/hooks';
 import {
   handleApikeyBlur,
   handleApikeyChange,
@@ -33,7 +35,7 @@ import {
   handleSerialNumberChange,
   handleTestModeChange,
   initialSpi,
-} from '../../../utils/common/pairHelpers';
+} from '../../../utils/common/pair/pairFormHelpers';
 import useLocalStorage from '../../../utils/hooks/useLocalStorage';
 import {
   fieldRequiredValidator,
@@ -54,10 +56,12 @@ const PairForm: React.FC = () => {
   const handleSubmit = (event: IPreventDefault) => {
     event.preventDefault();
   };
+  // read pair states
+  const pair = useAppSelector((state) => state.pair);
 
   return (
     <Grid container direction="column" className={classes.formContainer}>
-      <form autoComplete="off" onSubmit={handleSubmit}>
+      <form autoComplete="off" onSubmit={handleSubmit} className={classes.pairForm}>
         <Grid item className={classes.mainTitle}>
           <Typography variant="h6" component="h1">
             Configuration
@@ -67,6 +71,8 @@ const PairForm: React.FC = () => {
           <Grid container direction="row" className={classes.fieldSpace}>
             <Grid item xs={10} className={classes.columnSpace}>
               <CustomTextField
+                className={classes.paymentProvider}
+                disabled={pair.status === TEXT_STATUS_PAIRING}
                 error={!spi.provider.isValid}
                 fullWidth
                 helperText={
@@ -99,6 +105,7 @@ const PairForm: React.FC = () => {
               <Button
                 className={classes.spiBtn}
                 color="primary"
+                disabled={pair.status === TEXT_STATUS_PAIRING}
                 fullWidth
                 id="spiButton"
                 onClick={() => handleModalOpen(setSpi, 'provider')}
@@ -114,6 +121,7 @@ const PairForm: React.FC = () => {
                 <InputLabel id="configurationLabel">Configuration option</InputLabel>
                 <Select
                   className={classes.configurationField}
+                  disabled={pair.status === TEXT_STATUS_PAIRING}
                   id="configurationField"
                   label="Configuration option"
                   labelId="configurationDropdownLabel"
@@ -128,7 +136,10 @@ const PairForm: React.FC = () => {
             </Grid>
             <Grid item sm={6} xs={12}>
               <CustomTextField
-                disabled={spi.configuration.type === TEXT_FORM_CONFIGURATION_AUTO_ADDRESS_VALUE}
+                disabled={
+                  spi.configuration.type === TEXT_FORM_CONFIGURATION_AUTO_ADDRESS_VALUE ||
+                  pair.status === TEXT_STATUS_PAIRING
+                }
                 fullWidth
                 id="eftposAddressField"
                 label="EFTPOS address"
@@ -141,6 +152,7 @@ const PairForm: React.FC = () => {
           </Grid>
           <Grid item className={classes.fieldSpace}>
             <CustomTextField
+              disabled={pair.status === TEXT_STATUS_PAIRING}
               error={!spi.serialNumber.isValid}
               fullWidth
               helperText={!spi.serialNumber.isValid ? TEXT_FORM_VALIDATION_SERIAL_NUMBER_TEXTFIELD : ''}
@@ -161,6 +173,7 @@ const PairForm: React.FC = () => {
           </Grid>
           <Grid item className={classes.fieldSpace}>
             <CustomTextField
+              disabled={pair.status === TEXT_STATUS_PAIRING}
               error={!spi.posId.isValid}
               fullWidth
               helperText={!spi.posId.isValid ? TEXT_FORM_VALIDATION_POS_ID_TEXTFIELD : ''}
@@ -179,6 +192,7 @@ const PairForm: React.FC = () => {
           </Grid>
           <Grid item className={classes.fieldSpace}>
             <CustomTextField
+              disabled={pair.status === TEXT_STATUS_PAIRING}
               error={!spi.apikey.isValid}
               fullWidth
               helperText={!spi.apikey.isValid ? TEXT_FORM_VALIDATION_API_KEY_TEXTFIELD : ''}
@@ -201,6 +215,7 @@ const PairForm: React.FC = () => {
                 <Checkbox
                   checked={spi.testMode}
                   color="primary"
+                  disabled={pair.status === TEXT_STATUS_PAIRING}
                   id="testModeCheckbox"
                   name="testMode"
                   onChange={(event: IFormEventValue) => handleTestModeChange(setSpi, 'testMode')(event)}
@@ -210,11 +225,11 @@ const PairForm: React.FC = () => {
             />
           </Grid>
           <Grid item>
-            <Box marginTop={3} display="flex" justifyContent="flex-end">
+            <Box marginTop={1.5} display="flex" justifyContent="flex-end">
               <Button
                 color="primary"
                 className={classes.saveBtn}
-                disabled={!saveButtonValidator(spi)}
+                disabled={!saveButtonValidator(spi) || pair.status === TEXT_STATUS_PAIRING}
                 id="saveSettingsButton"
                 type="submit"
                 variant="contained"

--- a/src/components/PairPage/PairStatus/PairPanelButtons/index.tsx
+++ b/src/components/PairPage/PairStatus/PairPanelButtons/index.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import {
+  TEXT_STATUS_UNPAIRED,
+  TEXT_STATUS_PAIRING,
+  TEXT_STATUS_PAIRED,
+} from '../../../../definitions/constants/commonConfigs';
+import { ReactComponent as ConnectedIcon } from '../../../../images/ConnectedIcon.svg';
+import { ReactComponent as ReconnectingIcon } from '../../../../images/ReconnectingIcon.svg';
+import { ReactComponent as UnpairedIcon } from '../../../../images/UnpairedIcon.svg';
+import { useAppDispatch } from '../../../../redux/hooks';
+import handlePairClick from '../../../../utils/common/pair/pairStatusHelpers';
+import useStyles from '../index.styles';
+import { PairPanelButtonsInterface } from '../interfaces';
+
+export default function PairPanelButtons(status: string): PairPanelButtonsInterface {
+  const classes = useStyles();
+  const dispatch = useAppDispatch();
+
+  switch (status) {
+    case TEXT_STATUS_UNPAIRED:
+      return {
+        statusTitle: 'Unpaired',
+        statusIcon: <UnpairedIcon className={classes.unpairedIcon} />,
+        statusText: 'Idle',
+        button: (
+          <Button
+            variant="contained"
+            color="primary"
+            className={classes.pairBtn}
+            onClick={() => handlePairClick(dispatch)}
+          >
+            Pair
+          </Button>
+        ),
+      };
+    case TEXT_STATUS_PAIRING:
+      return {
+        statusTitle: 'Reconnecting',
+        statusIcon: <ReconnectingIcon className={classes.reconnectIcon} />,
+        statusText: 'Pairing',
+        button: (
+          <Button variant="outlined" className={classes.cancelPairingBtn}>
+            Cancel Pairing
+          </Button>
+        ),
+      };
+    case TEXT_STATUS_PAIRED:
+      return {
+        statusTitle: 'Connected',
+        statusIcon: <ConnectedIcon className={classes.connectedIcon} />,
+        statusText: 'Ready',
+        button: (
+          <Box>
+            <Button color="primary" className={classes.unpairButton}>
+              Unpair
+            </Button>
+            <Button variant="contained" color="primary" className={classes.pairBtn}>
+              Go to Sample POS
+            </Button>
+          </Box>
+        ),
+      };
+    default:
+      return {
+        statusTitle: 'Unpaired',
+        statusIcon: <UnpairedIcon className={classes.unpairedIcon} />,
+        statusText: 'Idle',
+        button: (
+          <Button
+            variant="contained"
+            color="primary"
+            className={classes.pairBtn}
+            onClick={() => handlePairClick(dispatch)}
+          >
+            Pair
+          </Button>
+        ),
+      };
+  }
+}

--- a/src/components/PairPage/PairStatus/PairPanelInformation/index.tsx
+++ b/src/components/PairPage/PairStatus/PairPanelInformation/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import useStyles from '../index.styles';
+import { PairPanelInformationInterface } from '../interfaces';
+
+export default function index({ title, content }: PairPanelInformationInterface): React.ReactElement {
+  const classes = useStyles();
+
+  return (
+    <Box display="flex" flexDirection="column" className={classes.statusInfoBox}>
+      <Typography variant="h6">{title}</Typography>
+      <Typography variant="inherit">{content}</Typography>
+    </Box>
+  );
+}

--- a/src/components/PairPage/PairStatus/index.styles.ts
+++ b/src/components/PairPage/PairStatus/index.styles.ts
@@ -1,0 +1,103 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    mainTitle: {
+      paddingBottom: theme.spacing(1.5),
+      background: theme.palette.background.default,
+    },
+    flowBox: {
+      height: '100%',
+      background: theme.palette.common.white,
+    },
+    flowToggle: {
+      zIndex: 2,
+    },
+    flowButton: {
+      color: 'inherit',
+      background: 'transparent',
+      border: 'none',
+      cursor: 'pointer',
+    },
+    flowIcon: {
+      cursor: 'pointer',
+    },
+    statusPanel: {
+      display: 'flex',
+      width: '100%',
+      flexGrow: 1,
+      padding: theme.spacing(1.5),
+    },
+    statusBox: {
+      padding: theme.spacing(1.5, 1),
+      background: theme.palette.background.default,
+      borderRadius: theme.spacing(0.625),
+      marginBottom: theme.spacing(1.5),
+      '& h5': {
+        fontSize: '1.125rem',
+        fontWeight: 500,
+        wordBreak: 'break-word',
+      },
+      '& span': {
+        fontSize: '0.875rem',
+        fontWeight: 400,
+        color: theme.palette.text.secondary,
+        wordBreak: 'break-word',
+      },
+      '&>.MuiTypography-root': {
+        display: 'flex',
+        alignItems: 'center',
+      },
+    },
+    statusInfoBox: {
+      marginBottom: theme.spacing(1.5),
+      paddingLeft: theme.spacing(1),
+      '& h6': {
+        fontSize: '1rem',
+        fontWeight: 500,
+      },
+      '& span': {
+        fontSize: '0.875rem',
+        fontWeight: 400,
+        color: theme.palette.text.secondary,
+      },
+    },
+    statusButtonBox: {
+      padding: theme.spacing(1.5),
+    },
+    unpairButton: {
+      color: 'inherit',
+      background: 'transparent',
+      border: 'none',
+      cursor: 'pointer',
+      marginBottom: theme.spacing(0.5),
+    },
+    pairBtn: {
+      marginBottom: theme.spacing(0.5),
+      textTransform: 'none',
+    },
+    cancelPairingBtn: {
+      background: theme.palette.common.white,
+      color: theme.palette.primary.main,
+      borderColor: theme.palette.primary.main,
+      textTransform: 'none',
+      '&:hover, &:active, &:focus': {
+        background: theme.palette.common.white,
+        color: theme.palette.primary.main,
+        borderColor: theme.palette.primary.main,
+      },
+      marginBottom: theme.spacing(0.5),
+    },
+    unpairedIcon: {
+      color: theme.palette.error.main,
+    },
+    reconnectIcon: {
+      color: theme.palette.warning.main,
+    },
+    connectedIcon: {
+      color: theme.palette.success.main,
+    },
+  })
+);
+
+export default useStyles;

--- a/src/components/PairPage/PairStatus/index.tsx
+++ b/src/components/PairPage/PairStatus/index.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import KeyboardArrowLeftIcon from '@material-ui/icons/KeyboardArrowLeft';
+import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
+import { useAppSelector } from '../../../redux/hooks';
+import useStyles from './index.styles';
+import { PairStatusInterface, PairStatusStatesInterface } from './interfaces';
+import PairPanelButtons from './PairPanelButtons';
+import PairPanelInformation from './PairPanelInformation';
+
+function PairStatus({ open, handleDrawerToggle }: PairStatusInterface): React.ReactElement {
+  const classes = useStyles();
+  const pair = useAppSelector((state) => state.pair);
+
+  const [pairPanel] = useState<PairStatusStatesInterface>({
+    // @TODO will setup 'setPairPanel' later when doing api integrations
+    merchantId: '-',
+    terminalId: '-',
+    battery: '-',
+  });
+
+  const panelInformationList = [
+    {
+      title: 'Merchant ID',
+      content: pairPanel.merchantId,
+    },
+    {
+      title: 'Terminal ID',
+      content: pairPanel.terminalId,
+    },
+    {
+      title: 'Battery',
+      content: pairPanel.battery,
+    },
+  ];
+
+  return (
+    <Grid container direction="column" className={classes.flowBox} id="pairStatus">
+      <Grid container direction="row" justifyContent="space-between" alignItems="center" className={classes.mainTitle}>
+        <Grid item xs={4}>
+          <Typography variant="h6" component="h1">
+            Status
+          </Typography>
+        </Grid>
+        <Grid item xs={8}>
+          <Grid
+            container
+            direction="row"
+            alignItems="center"
+            justifyContent="flex-end"
+            onClick={handleDrawerToggle}
+            className={classes.flowToggle}
+          >
+            {!open && <KeyboardArrowLeftIcon className={classes.flowIcon} />}
+            <Button color="primary" type="button" className={classes.flowButton}>
+              {open ? 'Hide' : 'Show'} flow
+            </Button>
+            {open && <KeyboardArrowRightIcon className={classes.flowIcon} />}
+          </Grid>
+        </Grid>
+      </Grid>
+      <Grid container direction="column" className={classes.statusPanel}>
+        <Box display="flex" alignItems="center" className={classes.statusBox}>
+          <Typography align="right">{PairPanelButtons(pair.status).statusIcon}</Typography>
+          <Box display="flex" flexDirection="column" marginLeft={2}>
+            <Typography variant="h5">{PairPanelButtons(pair.status).statusTitle}</Typography>
+            <Typography variant="inherit">{PairPanelButtons(pair.status).statusText}</Typography>
+          </Box>
+        </Box>
+        {panelInformationList.map(({ title, content }) => (
+          <PairPanelInformation key={title} title={title} content={content} />
+        ))}
+      </Grid>
+      <Grid container alignItems="center" justifyContent="flex-end" className={classes.statusButtonBox}>
+        {PairPanelButtons(pair.status).button}
+      </Grid>
+    </Grid>
+  );
+}
+
+export default PairStatus;

--- a/src/components/PairPage/PairStatus/interfaces/index.ts
+++ b/src/components/PairPage/PairStatus/interfaces/index.ts
@@ -1,0 +1,22 @@
+export interface PairPanelButtonsInterface {
+  statusTitle: string;
+  statusIcon: React.ReactNode;
+  statusText: string;
+  button: React.ReactNode;
+}
+
+export interface PairPanelInformationInterface {
+  title: string;
+  content: string;
+}
+
+export interface PairStatusInterface {
+  open: boolean;
+  handleDrawerToggle: () => void;
+}
+
+export interface PairStatusStatesInterface {
+  merchantId: string;
+  terminalId: string;
+  battery: string;
+}

--- a/src/components/PairPage/index.styles.ts
+++ b/src/components/PairPage/index.styles.ts
@@ -1,0 +1,79 @@
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import { drawerWidth } from '../../definitions/constants/commonConfigs';
+import { FlowPanelInterface } from './FlowPanel/interfaces';
+
+export default makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+    },
+    content: {
+      flexGrow: 1,
+      padding: theme.spacing(6),
+      transition: theme.transitions.create('margin', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen,
+      }),
+      marginRight: `${-drawerWidth}%`,
+    },
+    contentShift: {
+      transition: theme.transitions.create('margin', {
+        easing: theme.transitions.easing.easeOut,
+        duration: theme.transitions.duration.enteringScreen,
+      }),
+      marginRight: 0,
+    },
+    pairStatusContainer: {
+      marginBottom: -theme.spacing(2), // keep same position with configuration form save settings button
+    },
+    pairFormContainer: {
+      display: 'inherit',
+    },
+    [theme.breakpoints.between(960, 1025)]: {
+      root: {
+        '&>main': {
+          padding: theme.spacing(6, 2),
+        },
+        '& form': {
+          marginBottom: (flow: FlowPanelInterface) => (flow ? 0 : -theme.spacing(2)),
+        },
+      },
+    },
+    [theme.breakpoints.between(600, 959)]: {
+      root: {
+        '&>main': {
+          padding: theme.spacing(6, 0),
+        },
+      },
+      pairFormContainer: {
+        display: (flow: FlowPanelInterface) => (flow ? 'none' : 'block'),
+      },
+      pairStatusContainer: {
+        flexBasis: (flow: FlowPanelInterface) => (flow ? '100%' : '33.333333%'),
+        maxWidth: (flow: FlowPanelInterface) => (flow ? '100%' : '33.333333%'),
+      },
+    },
+    [theme.breakpoints.down(600)]: {
+      root: {
+        '&>main': {
+          padding: theme.spacing(6, 0),
+        },
+        '& form': {
+          marginBottom: theme.spacing(2),
+        },
+      },
+      pairFormContainer: {
+        display: (flow: FlowPanelInterface) => (flow ? 'none' : 'block'),
+        flexBasis: '100%',
+        maxWidth: '100%',
+        '&>div': {
+          paddingRight: 0,
+        },
+      },
+      pairStatusContainer: {
+        flexBasis: '100%',
+        maxWidth: '100%',
+      },
+    },
+  })
+);

--- a/src/components/PairPage/index.tsx
+++ b/src/components/PairPage/index.tsx
@@ -1,11 +1,42 @@
 import React from 'react';
+import Container from '@material-ui/core/Container';
+import Grid from '@material-ui/core/Grid';
+import useLocalStorage from '../../utils/hooks/useLocalStorage';
 import Layout from '../Layout';
+import FlowPanel from './FlowPanel';
+import { FlowPanelInterface } from './FlowPanel/interfaces';
+import useStyles from './index.styles';
 import PairForm from './PairForm';
+import PairStatus from './PairStatus';
 
-const Pair: React.FC = () => (
-  <Layout>
-    <PairForm />
-  </Layout>
-);
+const PairPage: React.FC = () => {
+  const [flow, setFlow] = useLocalStorage('pairFlow', true);
 
-export default Pair;
+  const handleDrawerToggle = () => {
+    setFlow(!flow);
+  };
+
+  const classes = useStyles(flow as unknown as FlowPanelInterface);
+
+  return (
+    <Layout>
+      <div className={classes.root}>
+        <main className={flow ? `${classes.content} ${classes.contentShift}` : classes.content}>
+          <Container maxWidth="md">
+            <Grid container spacing={1}>
+              <Grid item sm={8} xs={12} className={classes.pairFormContainer}>
+                <PairForm />
+              </Grid>
+              <Grid item sm={4} xs={12} className={classes.pairStatusContainer}>
+                <PairStatus open={flow} handleDrawerToggle={handleDrawerToggle} />
+              </Grid>
+            </Grid>
+          </Container>
+        </main>
+        <FlowPanel flow={flow} />
+      </div>
+    </Layout>
+  );
+};
+
+export default PairPage;

--- a/src/components/PurchasePage/index.test.tsx
+++ b/src/components/PurchasePage/index.test.tsx
@@ -26,8 +26,10 @@ describe('Test <PurchasePage />', () => {
                 class="MuiToolbar-root MuiToolbar-dense MuiToolbar-gutters"
               >
                 <button
+                  aria-label="menu"
                   class="MuiButtonBase-root MuiIconButton-root makeStyles-menuButton-4 MuiIconButton-colorInherit MuiIconButton-edgeStart"
                   data-testid="navbarMenuIcon"
+                  name="menuIcon"
                   tabindex="0"
                   type="button"
                 >
@@ -58,23 +60,6 @@ describe('Test <PurchasePage />', () => {
           <p>
             Purchase Page
           </p>
-          <div>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text"
-              tabindex="0"
-              type="button"
-            >
-              <span
-                class="MuiButton-label"
-              >
-                Counter is:
-                0
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
-          </div>
         </div>
       </div>
     `);

--- a/src/components/PurchasePage/index.tsx
+++ b/src/components/PurchasePage/index.tsx
@@ -1,25 +1,10 @@
 import React from 'react';
-import Button from '@material-ui/core/Button';
-import { useAppDispatch, useAppSelector } from '../../redux/hooks';
-import { incrementByAmount } from '../../redux/reducers/counterSlice';
 import Layout from '../Layout';
 
-const Purchase: React.FC = () => {
-  const count = useAppSelector((state) => state.counter.value);
-  const dispatch = useAppDispatch();
-
-  const handleClickCounter = () => {
-    dispatch(incrementByAmount(5));
-  };
-
-  return (
-    <Layout>
-      <p>Purchase Page</p>
-      <div>
-        <Button onClick={handleClickCounter}>Counter is: {count}</Button>
-      </div>
-    </Layout>
-  );
-};
+const Purchase: React.FC = () => (
+  <Layout>
+    <p>Purchase Page</p>
+  </Layout>
+);
 
 export default Purchase;

--- a/src/definitions/constants/commonConfigs.ts
+++ b/src/definitions/constants/commonConfigs.ts
@@ -9,3 +9,9 @@ export const TEXT_FORM_VALIDATION_API_KEY_TEXTFIELD = 'Please enter an API Key.'
 export const TEXT_FORM_VALIDATION_POS_ID_TEXTFIELD = 'Please enter a POS ID.';
 export const TEXT_FORM_VALIDATION_PROVIDER_TEXTFIELD = 'Please enter a supported provider.';
 export const TEXT_FORM_VALIDATION_SERIAL_NUMBER_TEXTFIELD = 'Please enter a 9 digits Serial number.';
+// pair status text
+export const TEXT_STATUS_UNPAIRED = 'Idle';
+export const TEXT_STATUS_PAIRING = 'Pairing';
+export const TEXT_STATUS_PAIRED = 'Transaction';
+// Pair Flow drawer width 4/12 (based on design required)
+export const drawerWidth = 33.33333;

--- a/src/redux/reducers/pairSlice.ts
+++ b/src/redux/reducers/pairSlice.ts
@@ -1,0 +1,25 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+// constants
+import { TEXT_STATUS_UNPAIRED } from '../../definitions/constants/commonConfigs';
+
+interface IPairState {
+  status: string;
+}
+
+const initialState: IPairState = {
+  status: TEXT_STATUS_UNPAIRED,
+};
+
+export const pairSlice = createSlice({
+  name: 'pairSlice',
+  initialState,
+  reducers: {
+    setPairStatus: (state, action: PayloadAction<string>) => {
+      state.status = action.payload;
+    },
+  },
+});
+
+export const { setPairStatus } = pairSlice.actions;
+
+export default pairSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,9 +1,9 @@
 import { configureStore } from '@reduxjs/toolkit';
-import counterReducer from './reducers/counterSlice';
+import pairReducer from './reducers/pairSlice';
 
 export const store = configureStore({
   reducer: {
-    counter: counterReducer,
+    pair: pairReducer,
   },
 });
 

--- a/src/utils/common/pair/pairFormHelpers.ts
+++ b/src/utils/common/pair/pairFormHelpers.ts
@@ -1,9 +1,9 @@
 import React from 'react';
-import { IFormEventValue, ISPIAttribute, ISPIData } from '../../components/PairPage/PairForm/interfaces';
+import { IFormEventValue, ISPIAttribute, ISPIData } from '../../../components/PairPage/PairForm/interfaces';
 import {
   TEXT_FORM_CONFIGURATION_AUTO_ADDRESS_VALUE,
   TEXT_FORM_CONFIGURATION_EFTPOS_ADDRESS_VALUE,
-} from '../../definitions/constants/commonConfigs';
+} from '../../../definitions/constants/commonConfigs';
 
 function isHttps(): boolean {
   return window.location.protocol === 'https:';

--- a/src/utils/common/pair/pairStatusHelpers.ts
+++ b/src/utils/common/pair/pairStatusHelpers.ts
@@ -1,0 +1,10 @@
+import { TEXT_STATUS_PAIRING } from '../../../definitions/constants/commonConfigs';
+import { setPairStatus } from '../../../redux/reducers/pairSlice';
+import { AppDispatch } from '../../../redux/store';
+
+// pair button click event
+function handlePairClick(dispatch: AppDispatch): void {
+  dispatch(setPairStatus(TEXT_STATUS_PAIRING));
+}
+
+export default handlePairClick;


### PR DESCRIPTION
* `Pair Status` Panel UI
* `Flow` panel UI 
* Introduced `redux` for pair status tracking
* Pair screen page layout setup
* Pair page `responsive` display support
* Renamed interface start from `I`
* Extracted `DrawerList` and `NavbarHeader` styles logic into an independent file
* Removed unused counter redux related code