### PR TITLE
moved reducer data normalization logic into spi service layer

### DIFF
--- a/src/components/FlowPanel/PairFlow/index.tsx
+++ b/src/components/FlowPanel/PairFlow/index.tsx
@@ -43,12 +43,12 @@ export default function PairFlow({ terminal }: ITerminal): React.ReactElement {
   const pairFlowInformation = (pairingFlow: IPairingFlow) => `
 ### PAIRING PROCESS UPDATE ###
 
-# ${pairingFlow.Message}
-# Finished? ${pairingFlow.Finished}
-# Successful? ${pairingFlow.Successful}
-# Confirmation Code: ${pairingFlow.ConfirmationCode}
-# Waiting Confirm from Eftpos? ${pairingFlow.AwaitingCheckFromEftpos}
-# Waiting Confirm from POS? ${pairingFlow.AwaitingCheckFromPos}
+# ${pairingFlow?.message}
+# Finished? ${pairingFlow?.finished}
+# Successful? ${pairingFlow?.successful}
+# Confirmation Code: ${pairingFlow?.confirmationCode}
+# Waiting Confirm from Eftpos? ${pairingFlow?.awaitingCheckFromEftpos}
+# Waiting Confirm from POS? ${pairingFlow?.awaitingCheckFromPos}
   `;
 
   const receiptInformation = (txFlowReceipt: ITerminalReceiptFormatProps) =>

--- a/src/components/OrderConfirmation/index.tsx
+++ b/src/components/OrderConfirmation/index.tsx
@@ -17,7 +17,14 @@ import {
 } from '@material-ui/core';
 import CreateIcon from '@material-ui/icons/Create';
 import { useDispatch, useSelector } from 'react-redux';
-import { PATH_CASH_OUT, PATH_PAY_NOW, PATH_REFUND } from '../../definitions/constants/routerConfigs';
+import {
+  PATH_CASH_OUT,
+  PATH_REFUND,
+  TEXT_PURCHASE,
+  TEXT_REFUND,
+  TEXT_CASHOUT,
+  PATH_PAY_NOW,
+} from '../../definitions/constants/routerConfigs';
 import { TxFlowState } from '../../definitions/constants/terminalConfigs';
 import {
   orderCashoutAmountSelector,
@@ -49,7 +56,7 @@ import TransactionProgressModal from '../TransactionProgressModal';
 import UnknownTransactionModal from '../UnknownTransactionModal';
 
 import useStyles from './index.styles';
-import { IOrderConfirmation } from './interfaces';
+import { IOrderConfirmation, ITitleStrategy } from './interfaces';
 
 function OrderConfirmation({ title, pathname, currentAmount }: IOrderConfirmation): React.ReactElement {
   const dispatch = useDispatch();
@@ -98,8 +105,14 @@ function OrderConfirmation({ title, pathname, currentAmount }: IOrderConfirmatio
     }
   }
 
-  function getTotalAmount(): number {
-    return subtotalAmount + tipAmount + surchargeAmount + cashoutAmount;
+  const titleStrategy: ITitleStrategy = {
+    Pay: `Override ${TEXT_PURCHASE} Amount`,
+    [TEXT_CASHOUT]: TEXT_CASHOUT,
+    [TEXT_REFUND]: TEXT_REFUND,
+  };
+
+  function getTitleForKeypad(): string {
+    return title in titleStrategy ? (titleStrategy as unknown as Record<string, keyof ITitleStrategy>)[title] : title;
   }
 
   return (
@@ -113,9 +126,9 @@ function OrderConfirmation({ title, pathname, currentAmount }: IOrderConfirmatio
       >
         <KeyPad
           open={displayKeypad}
-          title="Override Purchase amount"
-          subtitle="Enter purchase amount"
-          defaultAmount={getTotalAmount()}
+          title={getTitleForKeypad()}
+          subtitle={`Enter ${getTitleForKeypad().toLowerCase()} amount`}
+          defaultAmount={totalAmount}
           onClose={() => {
             setDisplayKeypad(false);
           }}

--- a/src/components/OrderConfirmation/interfaces/index.ts
+++ b/src/components/OrderConfirmation/interfaces/index.ts
@@ -3,3 +3,9 @@ export interface IOrderConfirmation {
   pathname: string;
   currentAmount: number;
 }
+
+export interface ITitleStrategy {
+  Pay: string;
+  Cashout: string;
+  Refund: string;
+}

--- a/src/components/PaymentSummary/__snapshots__/index.test.tsx.snap
+++ b/src/components/PaymentSummary/__snapshots__/index.test.tsx.snap
@@ -168,7 +168,7 @@ exports[`Test <PaymentSummary /> should match snapshot for Purchase failure 1`] 
       <div
         class="MuiPaper-root MuiBox-root MuiBox-root-138 makeStyles-paper-122 MuiPaper-elevation1 MuiPaper-rounded"
       >
-        $5.50
+        $1.00
       </div>
       <br />
       <div
@@ -256,7 +256,7 @@ exports[`Test <PaymentSummary /> should match snapshot for Purchase success 1`] 
       <div
         class="MuiPaper-root MuiBox-root MuiBox-root-114 makeStyles-paper-98 MuiPaper-elevation1 MuiPaper-rounded"
       >
-        $5.50
+        $1.00
       </div>
       <br />
       <div

--- a/src/components/PaymentSummary/index.tsx
+++ b/src/components/PaymentSummary/index.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { Box, Button, Divider, Grid, Paper, Typography } from '@material-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link as LinkRouter } from 'react-router-dom';
-import { PATH_PURCHASE } from '../../definitions/constants/routerConfigs';
+import { PATH_PURCHASE, TEXT_PURCHASE } from '../../definitions/constants/routerConfigs';
 import { ReactComponent as FailedIcon } from '../../images/FailedIcon.svg';
 import { ReactComponent as SuccessIcon } from '../../images/SuccessIcon.svg';
 
-import { productSubTotalSelector } from '../../redux/reducers/ProductSlice/productSelector';
+import { orderTotalSelector, productSubTotalSelector } from '../../redux/reducers/ProductSlice/productSelector';
 import { clearAllProducts } from '../../redux/reducers/ProductSlice/productSlice';
 import selectedTerminalIdSelector from '../../redux/reducers/SelectedTerminalSlice/selectedTerminalSliceSelector';
 import { ITerminalProps } from '../../redux/reducers/TerminalSlice/interfaces';
@@ -14,6 +14,7 @@ import {
   isTerminalTxFlowSuccess,
   terminalInstance,
   terminalTransactionTypeObject,
+  terminalTxAmount,
   terminalTxFlowFinishedTracker,
 } from '../../redux/reducers/TerminalSlice/terminalsSliceSelectors';
 import currencyFormat from '../../utils/common/intl/currencyFormatter';
@@ -29,7 +30,9 @@ function PaymentSummary(): React.ReactElement {
   const subtotalAmount = useSelector(productSubTotalSelector);
   const isTxFlowFinished = useSelector(terminalTxFlowFinishedTracker(selectedTerminal));
   const isTxFlowSuccess = useSelector(isTerminalTxFlowSuccess(selectedTerminal));
+  const transactionAmount = useSelector(terminalTxAmount(selectedTerminal));
   const { typePath, typeTitle } = useSelector(terminalTransactionTypeObject(selectedTerminal));
+  const originalTotalAmount: number = useSelector(orderTotalSelector);
 
   const clearAllProductsAction = () => {
     dispatch(clearAllProducts());
@@ -60,7 +63,7 @@ function PaymentSummary(): React.ReactElement {
           {currentTerminal?.deviceAddress} S/N {currentTerminal?.serialNumber}
         </Typography>
         <Box className={classes.paper} component={Paper}>
-          {currencyFormat((currentTerminal?.txFlow?.request?.data?.purchaseAmount ?? 0) / 100)}
+          {currencyFormat((typeTitle !== TEXT_PURCHASE ? transactionAmount ?? 0 : originalTotalAmount ?? 0) / 100)}
         </Box>
         {typePath === PATH_PURCHASE ? (
           <>
@@ -70,19 +73,19 @@ function PaymentSummary(): React.ReactElement {
             <OrderLineItem
               disabled
               label="Surcharge"
-              amount={currentTerminal?.txFlow?.request.data.surchargeAmount ?? 0}
+              amount={currentTerminal?.txFlow?.request?.data?.surchargeAmount ?? 0}
               viewOnly
             />
             <OrderLineItem
               disabled
               label="Cashout"
-              amount={currentTerminal?.txFlow?.request.data.cashAmount ?? 0}
+              amount={currentTerminal?.txFlow?.request?.data?.cashAmount ?? 0}
               viewOnly
             />
             <OrderLineItem
               disabled
               label="Tip"
-              amount={currentTerminal?.txFlow?.request.data.tipAmount ?? 0}
+              amount={currentTerminal?.txFlow?.request?.data?.tipAmount ?? 0}
               viewOnly
             />
           </>

--- a/src/components/PurchaseFlow/__snapshots__/index.test.tsx.snap
+++ b/src/components/PurchaseFlow/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test <PurchaseFlow /> should match SUCCESS STATUS contents as snapshot test 1`] = `
+<div>
+  <pre>
+    
+# ----------- STATUS -----------
+
+# WOOHOO - WE GOT PAID!
+# POS Reference: undefined
+# Response: undefined
+# RRN: undefined
+# Scheme: undefined
+
+# ----------- Customer Receipt -----------
+
+# PURCHASE: $0.00
+# TIP: $0.00
+# SURCHARGE: $0.00
+# CASHOUT: $0.00
+
+
+  </pre>
+</div>
+`;
+
+exports[`Test <PurchaseFlow /> should show FAILED STATUS contents as snapshot test 1`] = `
+<div>
+  <pre>
+    
+# ----------- STATUS -----------
+
+# WE DID NOT GET PAID :(
+# Error Detail: see 'host_response_text' for details
+# Response: undefined
+# RRN: undefined
+
+  </pre>
+</div>
+`;
+
+exports[`Test <PurchaseFlow /> should show TX PROCESS UPDATE contents as snapshot test 1`] = `
+<div>
+  <pre>
+    
+### TX PROCESS UPDATE ###
+
+# undefined
+# Request Id: undefined
+# PosRefId: undefined
+# Type: undefined
+# Request Amount: $0.00
+# Waiting For Signature: false
+# Finished: true
+# Success: Success
+
+  </pre>
+</div>
+`;

--- a/src/components/PurchaseFlow/index.test.tsx
+++ b/src/components/PurchaseFlow/index.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { cleanup } from '@testing-library/react';
+import PurchaseFlow from '.';
+import { TxFlowState } from '../../definitions/constants/terminalConfigs';
+import mockWithRedux, {
+  defaultMockPairFormParams,
+  defaultMockTerminals,
+  mockTerminalInstanceId,
+} from '../../utils/tests/common';
+
+describe('Test <PurchaseFlow />', () => {
+  afterEach(cleanup);
+
+  const genericCustomStore = (txFlow: Any) => ({
+    getState: () => ({
+      common: { showFlowPanel: false },
+      pairForm: defaultMockPairFormParams,
+      terminals: {
+        ...defaultMockTerminals,
+        [mockTerminalInstanceId]: {
+          ...defaultMockTerminals[mockTerminalInstanceId],
+          txFlow,
+        },
+      },
+      selectedTerminal: { selectedTerminalId: mockTerminalInstanceId },
+    }),
+    subscribe: jest.fn(),
+    dispatch: jest.fn(),
+  });
+
+  test('should match SUCCESS STATUS contents as snapshot test', () => {
+    // Arrange
+    const customStore = genericCustomStore({
+      awaitingSignatureCheck: true,
+      finished: true,
+      success: TxFlowState.Success,
+    });
+    const container = mockWithRedux(<PurchaseFlow />, customStore);
+
+    // Assert
+    expect(container).toMatchSnapshot();
+  });
+
+  test('should show TX PROCESS UPDATE contents as snapshot test', () => {
+    // Arrange
+    const customStore = genericCustomStore({
+      awaitingSignatureCheck: false,
+      finished: true,
+      success: TxFlowState.Success,
+    });
+    const container = mockWithRedux(<PurchaseFlow />, customStore);
+
+    // Assert
+    expect(container).toMatchSnapshot();
+  });
+
+  test('should show FAILED STATUS contents as snapshot test', () => {
+    // Arrange
+    const customStore = genericCustomStore({
+      awaitingSignatureCheck: false,
+      finished: false,
+      success: TxFlowState.Unknown,
+    });
+    const container = mockWithRedux(<PurchaseFlow />, customStore);
+
+    // Assert
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/PurchaseFlow/index.tsx
+++ b/src/components/PurchaseFlow/index.tsx
@@ -14,7 +14,6 @@ export default function PurchaseFlow(): React.ReactElement {
   const currentTerminal = useSelector(terminalInstance(selectedTerminal)) as ITerminalProps;
   const isSuccess = useSelector(isTerminalTxFlowSuccess(selectedTerminal));
   const awaitingSignatureCheck = useSelector(terminalTxFlowAwaitingSignatureTracker(selectedTerminal));
-
   const statusInformation = (spi: ITerminalProps) =>
     awaitingSignatureCheck
       ? `

--- a/src/components/TerminalsPage/TerminalDetails/TabPanel/index.test.tsx
+++ b/src/components/TerminalsPage/TerminalDetails/TabPanel/index.test.tsx
@@ -69,7 +69,7 @@ describe('Test <TabPanel />', () => {
     expect(container.innerHTML.includes('Test Panel Two')).toBeTruthy();
   });
 
-  test('should display receipt loading status message when txFlow Finished is false and success is Unknown', () => {
+  test('should display receipt loading status message when txFlow finished is false and success is Unknown', () => {
     // Arrange
     const customizedStore = {
       getState: () => ({
@@ -111,7 +111,7 @@ describe('Test <TabPanel />', () => {
     expect(newMockContainer.innerHTML.includes('Settle Initiated. Will be updated with Progress.')).toBe(true);
   });
 
-  test('should display receipt with error when txFlow Finished is false and success is Failed', () => {
+  test('should display receipt with error when txFlow finished is false and success is Failed', () => {
     // Arrange
     const customizedStore = {
       getState: () => ({
@@ -154,7 +154,7 @@ describe('Test <TabPanel />', () => {
     expect(newMockContainer.innerHTML.includes('Could not initiate settle:')).toBe(true);
   });
 
-  test('should display receipt content when txFlow Finished is true and success is Success', () => {
+  test('should display receipt content when txFlow finished is true and success is Success', () => {
     // Arrange
     const customizedStore = {
       getState: () => ({

--- a/src/redux/reducers/TerminalSlice/interfaces/index.ts
+++ b/src/redux/reducers/TerminalSlice/interfaces/index.ts
@@ -31,15 +31,6 @@ export interface ITerminal {
   terminal?: ITerminalProps | null;
 }
 
-export interface ITerminalConfig {
-  acquirerCode: string;
-  autoAddress: boolean;
-  deviceAddress: string;
-  posId: string;
-  secureWebSocket: boolean;
-  serialNumber: string;
-  testMode: boolean;
-}
 export interface ISettings {
   eftposReceipt: boolean;
   sigFlow: boolean;
@@ -96,12 +87,12 @@ export interface ITxFlow {
   };
 }
 export interface IPairingFlow {
-  Message: string;
-  AwaitingCheckFromEftpos: boolean;
-  AwaitingCheckFromPos: boolean;
-  ConfirmationCode: string;
-  Finished: boolean;
-  Successful: boolean;
+  message: string;
+  awaitingCheckFromEftpos: boolean;
+  awaitingCheckFromPos: boolean;
+  confirmationCode: string;
+  finished: boolean;
+  successful: boolean;
 }
 export interface ISecrets {
   encKey: string;
@@ -118,14 +109,28 @@ export interface ITxMessage {
 // Types for Actions
 export interface IAddTerminalAction {
   id: string;
-  pairFormValues: {
+  terminalConfigs: {
     acquirerCode: string;
     autoAddress: boolean;
     deviceAddress: string;
     posId: string;
+    secureWebSocket: boolean;
     serialNumber: string;
-    secrets: ISecrets | null;
     testMode: boolean;
+    pluginVersion: string;
+    merchantId: string;
+    terminalId: string;
+    batteryLevel: string;
+    flow: null;
+    id: string;
+    pairingFlow: null;
+    posVersion: string;
+    secrets: ISecrets | null;
+    settings: null;
+    status: string;
+    terminalStatus: string;
+    txFlow: null;
+    txMessage: null;
   };
 }
 export interface IUpdateDeviceAddressAction {
@@ -190,39 +195,7 @@ export interface IUpdateTxMessage {
 
 export interface IUpdateTerminalReceipt {
   id: string;
-  responseData: ITerminalReceiptRawProps;
-}
-
-export interface ITerminalReceiptRawProps {
-  accumulated_settle_by_acquirer_count: string;
-  accumulated_settle_by_acquirer_value: string;
-  accumulated_total_count: string;
-  accumulated_total_value: string;
-  bank_date: string;
-  bank_time: string;
-  error_detail: string;
-  error_reason: string;
-  host_response_code: string;
-  host_response_text: string;
-  merchant_acquirer: string;
-  merchant_address: string;
-  merchant_city: string;
-  merchant_country: string;
-  merchant_name: string;
-  merchant_postcode: string;
-  merchant_receipt: string;
-  merchant_receipt_printed: boolean;
-  schemes: Array<IReceiptSchemes>;
-  settlement_period_end_date: string;
-  settlement_period_end_time: string;
-  settlement_period_start_date: string;
-  settlement_period_start_time: string;
-  settlement_triggered_date: string;
-  settlement_triggered_time: string;
-  stan: string;
-  success: boolean;
-  terminal_id: string;
-  transaction_range: string;
+  receipt: ITerminalReceiptFormatProps;
 }
 
 export interface ITerminalReceiptFormatProps {

--- a/src/redux/reducers/TerminalSlice/terminalsSlice.test.ts
+++ b/src/redux/reducers/TerminalSlice/terminalsSlice.test.ts
@@ -1,6 +1,6 @@
 import { SPI_PAIR_STATUS } from '../../../definitions/constants/commonConfigs';
 import { defaultLocalIP } from '../../../definitions/constants/spiConfigs';
-import { mockReceiptRawResponse, mockReceiptResponse } from '../../../utils/tests/common';
+import { mockReceiptResponse } from '../../../utils/tests/common';
 import { IPairingFlow, IUpdateDeviceAddressAction, ITerminalState, ITxFlow } from './interfaces';
 import reducer, {
   addTerminal,
@@ -24,18 +24,18 @@ const mockTerminalInstanceId = '222-222-222';
 
 function mockPairingFlow(): IPairingFlow {
   const pairingFlow = {
-    Finished: true,
-    Message: 'Requesting to pair ..',
-    AwaitingCheckFromEftpos: false,
-    AwaitingCheckFromPos: false,
-    ConfirmationCode: '',
-    Successful: false,
+    finished: true,
+    message: 'Requesting to pair ..',
+    awaitingCheckFromEftpos: false,
+    awaitingCheckFromPos: false,
+    confirmationCode: '',
+    successful: false,
   };
 
   return pairingFlow;
 }
 
-function mockTerminalConfigurations() {
+function mockDefaultTerminalConfigurations() {
   return {
     acquirerCode: 'string',
     autoAddress: false,
@@ -45,7 +45,7 @@ function mockTerminalConfigurations() {
     secureWebSocket: true,
     serialNumber: mockTerminalInstanceId,
     testMode: true,
-    pairingFlow: mockPairingFlow(),
+    pairingFlow: null,
     pluginVersion: '-',
     merchantId: '-',
     terminalId: '-',
@@ -142,23 +142,14 @@ function mockTxFlow(): ITxFlow {
 test('should handle a initial add terminal state', () => {
   // Arrange
   const previousState = {};
-  const pairFormValues = {
-    acquirerCode: 'test',
-    autoAddress: false,
-    deviceAddress: defaultLocalIP,
-    posId: 'test',
-    secrets: null,
-    serialNumber: mockTerminalInstanceId,
-    testMode: false,
-  };
   const expectedState = {
-    acquirerCode: 'test',
+    acquirerCode: 'string',
     autoAddress: false,
     deviceAddress: defaultLocalIP,
-    posId: 'test',
+    posId: 'string',
     secureWebSocket: true,
     serialNumber: mockTerminalInstanceId,
-    testMode: false,
+    testMode: true,
     pluginVersion: '-',
     merchantId: '-',
     terminalId: '-',
@@ -178,7 +169,7 @@ test('should handle a initial add terminal state', () => {
   // Act
   const addTerminalAction = {
     id: mockTerminalInstanceId,
-    pairFormValues,
+    terminalConfigs: mockDefaultTerminalConfigurations(),
   };
 
   // Assert
@@ -193,7 +184,7 @@ test('should handle when terminal is added', () => {
   // Act
   const addTerminalAction = {
     id: mockTerminalInstanceId,
-    pairFormValues: mockTerminalConfigurations(),
+    terminalConfigs: mockDefaultTerminalConfigurations(),
   };
 
   // Assert
@@ -243,12 +234,12 @@ test('should handle updateDeviceAddress for empty state', () => {
 test('should handle updatePairingFlow', () => {
   // Arrange
   const mockPairingFlowResponse = {
-    Message: 'Connecting...',
-    AwaitingCheckFromEftpos: false,
-    AwaitingCheckFromPos: false,
-    ConfirmationCode: '',
-    Finished: false,
-    Successful: false,
+    message: 'Connecting...',
+    awaitingCheckFromEftpos: false,
+    awaitingCheckFromPos: false,
+    confirmationCode: '',
+    finished: false,
+    successful: false,
   };
 
   // Act
@@ -269,12 +260,12 @@ test('should handle updatePairingFlow', () => {
 test('should handle updatePairingFlow when empty state & unpaired', () => {
   // Arrange
   const mockPairingFlowResponse = {
-    Message: 'Connecting...',
-    AwaitingCheckFromEftpos: false,
-    AwaitingCheckFromPos: false,
-    ConfirmationCode: '',
-    Finished: false,
-    Successful: false,
+    message: 'Connecting...',
+    awaitingCheckFromEftpos: false,
+    awaitingCheckFromPos: false,
+    confirmationCode: '',
+    finished: false,
+    successful: false,
   };
   const previousState = {};
 
@@ -295,12 +286,12 @@ test('should handle updatePairingFlow when empty state & unpaired', () => {
 test('should handle updatePairingFlow when empty state & unpaired', () => {
   // Arrange
   const mockPairingFlowResponse = {
-    Message: 'Connecting...',
-    AwaitingCheckFromEftpos: false,
-    AwaitingCheckFromPos: false,
-    ConfirmationCode: '',
-    Finished: true,
-    Successful: false,
+    message: 'Connecting...',
+    awaitingCheckFromEftpos: false,
+    awaitingCheckFromPos: false,
+    confirmationCode: '',
+    finished: true,
+    successful: false,
   };
   const previousState = {};
 
@@ -406,43 +397,47 @@ test('should handle updateTerminal', () => {
   const updateTerminalAction = {
     id: mockTerminalInstanceId,
     spiClient: {
-      _acquirerCode: 'test',
-      _autoAddressResolutionEnabled: false,
-      _eftposAddress: defaultLocalIP,
-      _posId: 'test',
-      _forceSecureWebSockets: true,
-      _serialNumber: mockTerminalInstanceId,
-      _inTestMode: true,
-      CurrentFlow: null,
-      CurrentPairingFlowState: null,
-      _posVersion: '1.3.4',
-      _secrets: {
+      acquirerCode: 'test',
+      autoAddress: false,
+      deviceAddress: defaultLocalIP,
+      posId: 'test',
+      secureWebSocket: true,
+      serialNumber: mockTerminalInstanceId,
+      testMode: true,
+      flow: null,
+      id: mockTerminalInstanceId,
+      pairingFlow: null,
+      posVersion: '1.3.4',
+      secrets: {
         encKey: 'string',
         hmacKey: 'string',
       },
-      _currentStatus: 'Idle',
-      CurrentTxFlowState: null,
+      settings: null, // not available during pair terminal stage
+      status: 'Idle',
+      terminalStatus: null,
+      txFlow: null,
+      txMessage: null,
     },
   };
 
   const expectedResponse = {
-    acquirerCode: updateTerminalAction.spiClient._acquirerCode,
-    autoAddress: updateTerminalAction.spiClient._autoAddressResolutionEnabled,
-    deviceAddress: updateTerminalAction.spiClient._eftposAddress,
-    posId: updateTerminalAction.spiClient._posId,
-    secureWebSocket: updateTerminalAction.spiClient._forceSecureWebSockets,
-    serialNumber: updateTerminalAction.spiClient._serialNumber,
-    testMode: updateTerminalAction.spiClient._inTestMode,
-    flow: updateTerminalAction.spiClient.CurrentFlow,
-    id: updateTerminalAction.spiClient._serialNumber,
-    pairingFlow: updateTerminalAction.spiClient.CurrentPairingFlowState,
-    posVersion: updateTerminalAction.spiClient._posVersion,
-    secrets: updateTerminalAction.spiClient._secrets,
-    settings: null, // not available during pair terminal stage
-    status: updateTerminalAction.spiClient._currentStatus,
-    terminalStatus: updateTerminalAction.spiClient.CurrentFlow,
-    txFlow: updateTerminalAction.spiClient.CurrentTxFlowState,
-    txMessage: null,
+    acquirerCode: updateTerminalAction.spiClient.acquirerCode,
+    autoAddress: updateTerminalAction.spiClient.autoAddress,
+    deviceAddress: updateTerminalAction.spiClient.deviceAddress,
+    posId: updateTerminalAction.spiClient.posId,
+    secureWebSocket: updateTerminalAction.spiClient.secureWebSocket,
+    serialNumber: updateTerminalAction.spiClient.serialNumber,
+    testMode: updateTerminalAction.spiClient.testMode,
+    flow: updateTerminalAction.spiClient.flow,
+    id: updateTerminalAction.spiClient.id,
+    pairingFlow: updateTerminalAction.spiClient.pairingFlow,
+    posVersion: updateTerminalAction.spiClient.posVersion,
+    secrets: updateTerminalAction.spiClient.secrets,
+    settings: updateTerminalAction.spiClient.settings,
+    status: updateTerminalAction.spiClient.status,
+    terminalStatus: updateTerminalAction.spiClient.terminalStatus,
+    txFlow: updateTerminalAction.spiClient.txFlow,
+    txMessage: updateTerminalAction.spiClient.txMessage,
   };
 
   // Assert
@@ -705,7 +700,7 @@ test('should handle updateTxFlowSettlementResponse', () => {
   // Arrange
   const updateTxFlowSettlementResponseAction = {
     id: mockTerminalInstanceId,
-    responseData: mockReceiptRawResponse,
+    receipt: mockReceiptResponse,
   };
 
   // Assert
@@ -722,7 +717,7 @@ test('should handle updateTxFlowSettlementResponse for empty state', () => {
   const previousState = {};
   const updateTxFlowSettlementResponseAction = {
     id: mockTerminalInstanceId,
-    responseData: mockReceiptRawResponse,
+    receipt: mockReceiptResponse,
   };
 
   // Assert

--- a/src/redux/reducers/TerminalSlice/terminalsSlice.ts
+++ b/src/redux/reducers/TerminalSlice/terminalsSlice.ts
@@ -26,30 +26,7 @@ const terminalsSlice = createSlice({
   initialState,
   reducers: {
     addTerminal(state: ITerminalState, action: PayloadAction<IAddTerminalAction>) {
-      const { id, pairFormValues } = action.payload;
-      const terminalConfigs = {
-        acquirerCode: pairFormValues.acquirerCode,
-        autoAddress: pairFormValues.autoAddress,
-        deviceAddress: pairFormValues.deviceAddress,
-        posId: pairFormValues.posId,
-        secureWebSocket: true,
-        serialNumber: pairFormValues.serialNumber,
-        testMode: pairFormValues.testMode,
-        pluginVersion: '-',
-        merchantId: '-',
-        terminalId: '-',
-        batteryLevel: '-',
-        flow: null,
-        id: '',
-        pairingFlow: null,
-        posVersion: '',
-        secrets: pairFormValues.secrets,
-        settings: null, // not available during pair terminal stage
-        status: SPI_PAIR_STATUS.Unpaired,
-        terminalStatus: '',
-        txFlow: null,
-        txMessage: null, // not available during pair terminal stage
-      };
+      const { id, terminalConfigs } = action.payload;
 
       state[id] = terminalConfigs;
     },
@@ -66,6 +43,7 @@ const terminalsSlice = createSlice({
 
     removeTerminal(state: ITerminalState, action: PayloadAction<IRemoveTerminalAction>) {
       const { id } = action.payload;
+
       delete state[id];
     },
 
@@ -81,18 +59,10 @@ const terminalsSlice = createSlice({
       const { id, pairingFlow } = action.payload;
       const currentState = state[id] || {};
 
-      currentState.pairingFlow = {
-        Message: pairingFlow.Message,
-        AwaitingCheckFromEftpos: pairingFlow.AwaitingCheckFromEftpos,
-        AwaitingCheckFromPos: pairingFlow.AwaitingCheckFromPos,
-        ConfirmationCode: pairingFlow.ConfirmationCode,
-        Finished: pairingFlow.Finished,
-        Successful: pairingFlow.Successful,
-      };
-
       // can also dispatch updatePairingStatus from spiService when below condition is true
-      if (pairingFlow.Finished && !pairingFlow.Successful) currentState.status = SpiStatus.Unpaired;
+      if (pairingFlow?.finished && !pairingFlow?.successful) currentState.status = SpiStatus.Unpaired;
 
+      currentState.pairingFlow = pairingFlow;
       state[id] = currentState;
     },
 
@@ -118,27 +88,7 @@ const terminalsSlice = createSlice({
     updateTerminal(state: ITerminalState, action: PayloadAction<Any>) {
       const { id, spiClient } = action.payload;
 
-      const response = {
-        acquirerCode: spiClient._acquirerCode,
-        autoAddress: spiClient._autoAddressResolutionEnabled,
-        deviceAddress: spiClient._eftposAddress,
-        posId: spiClient._posId,
-        secureWebSocket: spiClient._forceSecureWebSockets,
-        serialNumber: spiClient._serialNumber,
-        testMode: spiClient._inTestMode,
-        flow: spiClient.CurrentFlow,
-        id: spiClient._serialNumber,
-        pairingFlow: spiClient.CurrentPairingFlowState,
-        posVersion: spiClient._posVersion,
-        secrets: spiClient._secrets,
-        settings: null, // not available during pair terminal stage
-        status: spiClient._currentStatus,
-        terminalStatus: spiClient.CurrentFlow,
-        txFlow: spiClient.CurrentTxFlowState,
-        txMessage: null, // not available during pair terminal stage
-      };
-
-      state[id] = response;
+      state[id] = spiClient;
     },
 
     updateTerminalConfigurations(state: ITerminalState, action: PayloadAction<IConfigurations>) {
@@ -178,46 +128,17 @@ const terminalsSlice = createSlice({
     },
 
     updateTxFlowSettlementResponse(state: ITerminalState, action: PayloadAction<IUpdateTerminalReceipt>) {
-      const { id, responseData } = action.payload;
+      const { id, receipt } = action.payload;
       const currentState = state[id] || {};
-      currentState.receipt = {
-        accumulatedSettleByAcquirerCount: responseData?.accumulated_settle_by_acquirer_count,
-        accumulatedSettleByAcquirerValue: responseData?.accumulated_settle_by_acquirer_value,
-        accumulatedTotalCount: responseData?.accumulated_total_count,
-        accumulatedTotalValue: responseData?.accumulated_total_value,
-        bankDate: responseData?.bank_date,
-        bankTime: responseData?.bank_time,
-        errorDetail: responseData?.error_detail,
-        errorReason: responseData?.error_reason,
-        hostResponseCode: responseData?.host_response_code,
-        hostResponseText: responseData?.host_response_text,
-        merchantAcquirer: responseData?.merchant_acquirer,
-        merchantAddress: responseData?.merchant_address,
-        merchantCity: responseData?.merchant_city,
-        merchantCountry: responseData?.merchant_country,
-        merchantName: responseData?.merchant_name,
-        merchantPostcode: responseData?.merchant_postcode,
-        merchantReceipt: responseData?.merchant_receipt,
-        merchantReceiptPrinted: responseData?.merchant_receipt_printed,
-        schemes: responseData?.schemes,
-        settlementPeriodEndDate: responseData?.settlement_period_end_date,
-        settlementPeriodEndTime: responseData?.settlement_period_end_time,
-        settlementPeriodStartDate: responseData?.settlement_period_start_date,
-        settlementPeriodStartTime: responseData?.settlement_period_start_time,
-        settlementTriggeredDate: responseData?.settlement_triggered_date,
-        settlementTriggeredTime: responseData?.settlement_triggered_time,
-        stan: responseData?.stan,
-        success: responseData?.success,
-        terminalId: responseData?.terminal_id,
-        transactionRange: responseData?.transaction_range,
-      };
 
+      currentState.receipt = receipt;
       state[id] = currentState;
     },
 
     updateTxFlow(state: ITerminalState, action: PayloadAction<IUpdateTxFlowAction>) {
       const { id, txFlow } = action.payload;
       const currentState = state[id] || {};
+
       currentState.txFlow = txFlow;
       state[id] = currentState;
     },

--- a/src/utils/common/pair/pairStatusHelpers.ts
+++ b/src/utils/common/pair/pairStatusHelpers.ts
@@ -7,7 +7,31 @@ import spiService from '../../../services/spiService';
 // pair terminal
 async function handlePairClick(dispatch: AppDispatch, pairFormValues: IPairFormValues): Promise<void> {
   const instanceId = pairFormValues.serialNumber;
-  dispatch(addTerminal({ id: instanceId, pairFormValues }));
+  const terminalConfigs = {
+    acquirerCode: pairFormValues?.acquirerCode,
+    autoAddress: pairFormValues?.autoAddress,
+    deviceAddress: pairFormValues?.deviceAddress,
+    posId: pairFormValues?.posId,
+    secureWebSocket: true,
+    serialNumber: instanceId,
+    testMode: pairFormValues?.testMode,
+    pluginVersion: '-',
+    merchantId: '-',
+    terminalId: '-',
+    batteryLevel: '-',
+    flow: null,
+    id: instanceId,
+    pairingFlow: null,
+    posVersion: '',
+    secrets: pairFormValues?.secrets,
+    settings: null, // not available during pair terminal stage
+    status: SPI_PAIR_STATUS.Unpaired,
+    terminalStatus: '',
+    txFlow: null,
+    txMessage: null, // not available during pair terminal stage
+  };
+
+  dispatch(addTerminal({ id: instanceId, terminalConfigs }));
   // start pairing
   spiService.spiTerminalPair(instanceId, pairFormValues);
   // update terminal connection status when starting to pair a terminal

--- a/src/utils/tests/common.tsx
+++ b/src/utils/tests/common.tsx
@@ -178,24 +178,24 @@ export const pairedMockTerminals = {
 };
 
 export const mockPairingFlow = {
-  Message: 'Requesting to Pair...',
-  AwaitingCheckFromEftpos: false,
-  AwaitingCheckFromPos: false,
-  ConfirmationCode: '',
-  Finished: false,
-  Successful: false,
+  message: 'Requesting to Pair...',
+  awaitingCheckFromEftpos: false,
+  awaitingCheckFromPos: false,
+  confirmationCode: '',
+  finished: false,
+  successful: false,
 };
 
 export const defaultTerminalFlow = {
   [mockTerminalInstanceId]: {
     status: SPI_PAIR_STATUS.Unpaired,
     pairingFlow: {
-      Message: 'Requesting to Pair...',
-      AwaitingCheckFromEftpos: false,
-      AwaitingCheckFromPos: false,
-      ConfirmationCode: '',
-      Finished: false,
-      Successful: false,
+      message: 'Requesting to Pair...',
+      awaitingCheckFromEftpos: false,
+      awaitingCheckFromPos: false,
+      confirmationCode: '',
+      finished: false,
+      successful: false,
     },
     terminalConfig: {
       deviceAddress: defaultAAR,
@@ -399,45 +399,6 @@ export const mockTerminalInstance: ITerminal = {
   spi_receipt_header: 'test',
   spi_receipt_footer: 'test',
   use_secure_web_sockets: false,
-};
-
-export const mockReceiptRawResponse = {
-  accumulated_settle_by_acquirer_count: 'string',
-  accumulated_settle_by_acquirer_value: 'string',
-  accumulated_total_count: 'string',
-  accumulated_total_value: 'string',
-  bank_date: 'string',
-  bank_time: 'string',
-  error_detail: 'string',
-  error_reason: 'string',
-  host_response_code: 'string',
-  host_response_text: 'string',
-  merchant_acquirer: 'string',
-  merchant_address: 'string',
-  merchant_city: 'string',
-  merchant_country: 'string',
-  merchant_name: 'string',
-  merchant_postcode: 'string',
-  merchant_receipt: mockReceiptContent,
-  merchant_receipt_printed: false,
-  schemes: [
-    {
-      scheme_name: 'string',
-      settle_by_acquirer: 'string',
-      total_count: 'string',
-      total_value: 'string',
-    },
-  ],
-  settlement_period_end_date: 'string',
-  settlement_period_end_time: 'string',
-  settlement_period_start_date: 'string',
-  settlement_period_start_time: 'string',
-  settlement_triggered_date: 'string',
-  settlement_triggered_time: 'string',
-  stan: 'string',
-  success: true,
-  terminal_id: 'string',
-  transaction_range: 'string',
 };
 
 export const mockReceiptResponse = {


### PR DESCRIPTION
* moved terminal data normalisation logic from reducer layer to spi service layer
* fixed the payment issues of wrong keypad value when switching to a different page
* corrected the cashout and refund keypad page title and subtitle
* fixed the total amount (including surcharge and cashout and tips) display after payment/order finished
* fixed a few unit tests after the corresponding changes made