### PR TITLE
Bugfix/send test mode to spi

### DIFF
--- a/src/components/PairPage/PairForm/PairConfiguration/index.tsx
+++ b/src/components/PairPage/PairForm/PairConfiguration/index.tsx
@@ -41,6 +41,7 @@ import {
   handleSerialNumberFieldOnChange,
   handlePosIdFieldOnBlur,
   handlePosIdFieldOnChange,
+  isHttps,
 } from '../../../../utils/common/pair/pairFormHelpers';
 import {
   eftposAddressValidator,
@@ -135,8 +136,12 @@ export default function PairConfiguration(): React.ReactElement {
                 }
                 value={addressType}
               >
-                <MenuItem value={TEXT_FORM_CONFIGURATION_AUTO_ADDRESS_VALUE}>Auto address</MenuItem>
-                <MenuItem value={TEXT_FORM_CONFIGURATION_EFTPOS_ADDRESS_VALUE}>EFTPOS address</MenuItem>
+                <MenuItem value={TEXT_FORM_CONFIGURATION_AUTO_ADDRESS_VALUE} disabled={!isHttps()}>
+                  Auto address
+                </MenuItem>
+                <MenuItem value={TEXT_FORM_CONFIGURATION_EFTPOS_ADDRESS_VALUE} disabled={isHttps()}>
+                  EFTPOS address
+                </MenuItem>
               </Select>
             </FormControl>
           </Grid>

--- a/src/services/spiService/index.ts
+++ b/src/services/spiService/index.ts
@@ -139,7 +139,7 @@ class SpiService {
       instance.spiClient.SetPosInfo(defaultPosName, currentVersion);
       instance.spiClient.SetAcquirerCode(acquirerCode);
       instance.spiClient.SetDeviceApiKey(defaultApikey);
-      instance.spiClient._inTestMode = testMode;
+      instance.spiClient.SetTestMode(testMode);
 
       // setup terminal id in localStorage
       this.updateTerminalStorage(instanceId, 'id', serialNumber);
@@ -232,8 +232,8 @@ class SpiService {
           instance.spi.PairingConfirmCode();
         }
 
-        if (detail?.message === 'Pairing Failed') {
-          this.handleTerminalPairFailure(instanceId, detail?.message);
+        if (detail?.Message === 'Pairing Failed') {
+          this.handleTerminalPairFailure(instanceId, detail?.Message);
           this.removeTerminalInstance(instanceId);
         }
 


### PR DESCRIPTION
* send test mode to spi library for production terminals HTTPS connection testing
* disabled EFTPOS address option from dropdown when HTTPS connection detected
* disabled Auto address option from dropdown when HTTP connection detected
* show SnackBar error message when pair error detected.