### PR TITLE
fixed order finished page amount value shown as 0 issue

### DIFF
--- a/src/components/FlowPanel/PairFlow/index.test.tsx
+++ b/src/components/FlowPanel/PairFlow/index.test.tsx
@@ -41,7 +41,7 @@ describe('Test <FlowPanel />', () => {
 
   afterEach(cleanup);
 
-  test('should show not paring flow params', () => {
+  test('should show IP address as eftpos address', () => {
     // Arrange
     const EFTPOS = defaultLocalIP;
 
@@ -55,7 +55,7 @@ describe('Test <FlowPanel />', () => {
       'Requesting to Pair...',
       'Finished? false',
       'Successful? false',
-      'Confirmation Code',
+      'Confirmation Code: -',
       'Waiting Confirm from Eftpos? false',
       'Waiting Confirm from POS? false',
     ];

--- a/src/components/FlowPanel/PairFlow/index.tsx
+++ b/src/components/FlowPanel/PairFlow/index.tsx
@@ -46,7 +46,7 @@ export default function PairFlow({ terminal }: ITerminal): React.ReactElement {
 # ${pairingFlow?.message}
 # Finished? ${pairingFlow?.finished}
 # Successful? ${pairingFlow?.successful}
-# Confirmation Code: ${pairingFlow?.confirmationCode}
+# Confirmation Code: ${pairingFlow?.confirmationCode || '-'}
 # Waiting Confirm from Eftpos? ${pairingFlow?.awaitingCheckFromEftpos}
 # Waiting Confirm from POS? ${pairingFlow?.awaitingCheckFromPos}
   `;

--- a/src/components/OrderConfirmation/index.test.tsx
+++ b/src/components/OrderConfirmation/index.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { fireEvent, screen, cleanup, waitFor } from '@testing-library/react';
 import * as redux from 'react-redux';
 import OrderConfirmation from '.';
-import { PATH_PAY_NOW } from '../../definitions/constants/routerConfigs';
+import { PATH_CASH_OUT, PATH_PAY_NOW, PATH_REFUND } from '../../definitions/constants/routerConfigs';
 import { TxFlowState } from '../../definitions/constants/terminalConfigs';
 import { store } from '../../redux/store';
 import spiService from '../../services/spiService';
@@ -29,6 +29,7 @@ describe('Test <OrderConfirmation />', () => {
         pairForm: defaultMockPairFormParams,
         terminals: pairedMockTerminals,
         products: {
+          keypadAmount: 0,
           surchargeAmount: 100,
           tipAmount: 100,
           cashoutAmount: 100,
@@ -76,6 +77,7 @@ describe('Test <OrderConfirmation />', () => {
   });
 
   test('should initiate purchase on clicking Card button', () => {
+    // Arrange
     const initiatePurchaseTransaction = jest.spyOn(spiService, 'initiatePurchaseTransaction');
     initiatePurchaseTransaction.mockReturnValue();
 
@@ -100,6 +102,7 @@ describe('Test <OrderConfirmation />', () => {
   });
 
   test('should cancel moto purchase on clicking Cancel button', () => {
+    // Arrange
     const initiateMotoPurchaseTransaction = jest.spyOn(spiService, 'initiateMotoPurchaseTransaction');
     initiateMotoPurchaseTransaction.mockReturnValue();
 
@@ -109,6 +112,7 @@ describe('Test <OrderConfirmation />', () => {
         common: { showFlowPanel: false, acquireConfirmPairingFlow: false },
         terminals: mockTerminals,
         products: {
+          keypadAmount: 0,
           surchargeAmount: 100,
           tipAmount: 100,
           cashoutAmount: 100,
@@ -147,6 +151,7 @@ describe('Test <OrderConfirmation />', () => {
   });
 
   test('should clearAll products when total amount is changed', () => {
+    // Arrange
     const initiateMotoPurchaseTransaction = jest.spyOn(spiService, 'initiateMotoPurchaseTransaction');
     initiateMotoPurchaseTransaction.mockReturnValue();
 
@@ -160,12 +165,14 @@ describe('Test <OrderConfirmation />', () => {
     fireEvent.click(screen.getByText(/ok/i));
 
     // Assert
-    expect(dispatch.mock.calls[0][0]).toEqual({
+    expect(dispatch.mock.calls[1][0]).toEqual({
       payload: undefined,
       type: 'product/clearAllProducts',
     });
   });
+
   test('should close the keypad', async () => {
+    // Arrange
     const initiateMotoPurchaseTransaction = jest.spyOn(spiService, 'initiateMotoPurchaseTransaction');
     initiateMotoPurchaseTransaction.mockReturnValue();
 
@@ -181,5 +188,33 @@ describe('Test <OrderConfirmation />', () => {
     await waitFor(() => {
       expect(screen.queryByLabelText(/close button/i)).not.toBeInTheDocument();
     });
+  });
+
+  test('should show cashout button when pathname is cashout', () => {
+    // Arrange
+    const initiateCashoutOnlyTxTransaction = jest.spyOn(spiService, 'initiateCashoutOnlyTxTransaction');
+    initiateCashoutOnlyTxTransaction.mockReturnValue();
+
+    // Act
+    mockWithRedux(<OrderConfirmation title="title" pathname={PATH_CASH_OUT} currentAmount={500} />, customStore);
+    const cashoutButton = screen.queryByText(/Cashout/i);
+    fireEvent.click(cashoutButton as Element);
+
+    // Assert
+    expect(cashoutButton).toBeInTheDocument();
+  });
+
+  test('should show refund button when pathname is refund', () => {
+    // Arrange
+    const initiateRefundTxTransaction = jest.spyOn(spiService, 'initiateRefundTxTransaction');
+    initiateRefundTxTransaction.mockReturnValue();
+
+    // Act
+    mockWithRedux(<OrderConfirmation title="title" pathname={PATH_REFUND} currentAmount={500} />, customStore);
+    const refundButton = screen.queryByText(/Refund/i);
+    fireEvent.click(refundButton as Element);
+
+    // Assert
+    expect(refundButton).toBeInTheDocument();
   });
 });

--- a/src/components/OrderConfirmation/index.tsx
+++ b/src/components/OrderConfirmation/index.tsx
@@ -32,7 +32,7 @@ import {
   orderTipAmountSelector,
   productSubTotalSelector,
 } from '../../redux/reducers/ProductSlice/productSelector';
-import { clearAllProducts } from '../../redux/reducers/ProductSlice/productSlice';
+import { addKeypadAmount, clearAllProducts } from '../../redux/reducers/ProductSlice/productSlice';
 import { updateSelectedTerminal } from '../../redux/reducers/SelectedTerminalSlice/selectedTerminalSlice';
 import selectedTerminalIdSelector from '../../redux/reducers/SelectedTerminalSlice/selectedTerminalSliceSelector';
 import { ITerminalProps } from '../../redux/reducers/TerminalSlice/interfaces';
@@ -133,6 +133,7 @@ function OrderConfirmation({ title, pathname, currentAmount }: IOrderConfirmatio
             setDisplayKeypad(false);
           }}
           onAmountChange={(amount) => {
+            dispatch(addKeypadAmount(amount));
             setTotalAmount(amount);
             setSubtotalAmount(amount);
             setDisplayKeypad(false);

--- a/src/components/PaymentSummary/index.test.tsx
+++ b/src/components/PaymentSummary/index.test.tsx
@@ -32,6 +32,7 @@ describe('Test <PaymentSummary />', () => {
         pairForm: defaultMockPairFormParams,
         terminals: mockTerminals,
         products: {
+          keypadAmount: 0,
           surchargeAmount: 100,
           tipAmount: 100,
           cashoutAmount: 100,

--- a/src/components/PurchasePage/Order/index.test.tsx
+++ b/src/components/PurchasePage/Order/index.test.tsx
@@ -64,6 +64,9 @@ describe('Test <Order />', () => {
     fireEvent.click(getAllByLabelText(/add amount/i)[0]);
     expect(getByText(/enter surcharge amount/i)).toBeVisible();
 
+    fireEvent.click(getAllByLabelText(/add amount/i)[1]);
+    expect(getByText(/enter cashout amount/i)).toBeVisible();
+
     fireEvent.click(getByLabelText(/close button/i));
     expect(dispatch.mock.calls.length).toBe(0);
   });

--- a/src/redux/reducers/CommonSlice/commonSliceSelectors.test.ts
+++ b/src/redux/reducers/CommonSlice/commonSliceSelectors.test.ts
@@ -12,6 +12,7 @@ describe('Test CommonSelectors', () => {
       common: { showFlowPanel: false },
       pairForm: defaultMockPairFormParams,
       products: {
+        keypadAmount: 0,
         tipAmount: 0,
         cashoutAmount: 0,
         surchargeAmount: 0,

--- a/src/redux/reducers/PairFormSlice/PairFormSelectors.test.ts
+++ b/src/redux/reducers/PairFormSlice/PairFormSelectors.test.ts
@@ -41,6 +41,7 @@ describe('Test PairFormSelectors', () => {
       pairForm: { ...mockPairFormParamsState, secrets: null },
       terminals: {},
       products: {
+        keypadAmount: 0,
         tipAmount: 0,
         cashoutAmount: 0,
         surchargeAmount: 0,
@@ -70,6 +71,7 @@ describe('Test PairFormSelectors', () => {
       },
       terminals: {},
       products: {
+        keypadAmount: 0,
         tipAmount: 0,
         cashoutAmount: 0,
         surchargeAmount: 0,

--- a/src/redux/reducers/ProductSlice/interfaces/index.ts
+++ b/src/redux/reducers/ProductSlice/interfaces/index.ts
@@ -1,4 +1,5 @@
 export interface IProductState {
+  keypadAmount: number;
   surchargeAmount: number;
   tipAmount: number;
   cashoutAmount: number;

--- a/src/redux/reducers/ProductSlice/productSelector.test.ts
+++ b/src/redux/reducers/ProductSlice/productSelector.test.ts
@@ -11,6 +11,7 @@ test('should return product quantity for list', () => {
     pair: { status: '' },
     terminals: {},
     products: {
+      keypadAmount: 0,
       surchargeAmount: 100,
       tipAmount: 100,
       cashoutAmount: 100,
@@ -31,6 +32,7 @@ test('should return product quantity for duplicate product', () => {
     pair: { status: '' },
     terminals: {},
     products: {
+      keypadAmount: 0,
       surchargeAmount: 100,
       tipAmount: 100,
       cashoutAmount: 100,
@@ -49,11 +51,27 @@ test('should return product quantity for duplicate product', () => {
   ]);
 });
 
+test('should return keypad amount as subtotal amount', () => {
+  const state = {
+    pair: { status: '' },
+    terminals: {},
+    products: {
+      keypadAmount: 500,
+      surchargeAmount: 100,
+      tipAmount: 120,
+      cashoutAmount: 110,
+      products: [],
+    },
+  };
+  expect(productSubTotalSelector(state)).toEqual(500);
+});
+
 test('should add all the price and display subtotal', () => {
   const state = {
     pair: { status: '' },
     terminals: {},
     products: {
+      keypadAmount: 0,
       surchargeAmount: 100,
       tipAmount: 100,
       cashoutAmount: 100,
@@ -74,6 +92,7 @@ test('should get surcharge amount', () => {
     pair: { status: '' },
     terminals: {},
     products: {
+      keypadAmount: 0,
       surchargeAmount: 155,
       tipAmount: 125,
       cashoutAmount: 0,
@@ -88,6 +107,7 @@ test('should get tip amount', () => {
     pair: { status: '' },
     terminals: {},
     products: {
+      keypadAmount: 0,
       surchargeAmount: 155,
       tipAmount: 125,
       cashoutAmount: 0,
@@ -102,6 +122,7 @@ test('should get cashout amount', () => {
     pair: { status: '' },
     terminals: {},
     products: {
+      keypadAmount: 0,
       surchargeAmount: 155,
       tipAmount: 0,
       cashoutAmount: 125,

--- a/src/redux/reducers/ProductSlice/productSelector.ts
+++ b/src/redux/reducers/ProductSlice/productSelector.ts
@@ -4,6 +4,8 @@ import { IProductSelector, IProductSelectorMap, IProductState } from './interfac
 
 const products = (state: ISamplePosState) => state.products;
 
+export const orderKeypadAmountSelector = createSelector(products, (state: IProductState): number => state.keypadAmount);
+
 export const productsSelector = createSelector(products, (state: IProductState): Array<IProductSelector> => {
   const productMap: IProductSelectorMap = {};
 
@@ -19,8 +21,10 @@ export const productsSelector = createSelector(products, (state: IProductState):
 });
 
 export const productSubTotalSelector = createSelector(
+  orderKeypadAmountSelector,
   productsSelector,
-  (productSelect: Array<IProductSelector>): number => {
+  (subtotalAmount, productSelect: Array<IProductSelector>): number => {
+    if (subtotalAmount > 0) return subtotalAmount;
     const subTotal = productSelect.reduce((prev, current) => prev + current.quantity * current.product.price, 0);
     return subTotal;
   }

--- a/src/redux/reducers/ProductSlice/productSlice.test.ts
+++ b/src/redux/reducers/ProductSlice/productSlice.test.ts
@@ -9,6 +9,7 @@ import reducer, {
 
 test('should handle add product', () => {
   const previousState: IProductState = {
+    keypadAmount: 0,
     surchargeAmount: 0,
     tipAmount: 0,
     cashoutAmount: 0,
@@ -16,6 +17,7 @@ test('should handle add product', () => {
   };
   const action = { product: { id: 1, name: 'Latte', price: 360, image: 'Latte.jpeg' } };
   expect(reducer(previousState, addProduct(action))).toEqual({
+    keypadAmount: 0,
     surchargeAmount: 0,
     tipAmount: 0,
     cashoutAmount: 0,
@@ -32,6 +34,7 @@ test('should handle add product', () => {
 
 test('should handle clear products', () => {
   const previousState: IProductState = {
+    keypadAmount: 0,
     surchargeAmount: 0,
     tipAmount: 0,
     cashoutAmount: 0,
@@ -51,6 +54,7 @@ test('should handle clear products', () => {
     ],
   };
   expect(reducer(previousState, clearAllProducts())).toEqual({
+    keypadAmount: 0,
     surchargeAmount: 0,
     tipAmount: 0,
     cashoutAmount: 0,
@@ -60,12 +64,14 @@ test('should handle clear products', () => {
 
 test('should add surcharge amount', () => {
   const previousState: IProductState = {
+    keypadAmount: 0,
     surchargeAmount: 0,
     tipAmount: 0,
     cashoutAmount: 0,
     products: [],
   };
   expect(reducer(previousState, addSurchargeAmount(105))).toEqual({
+    keypadAmount: 0,
     surchargeAmount: 105,
     tipAmount: 0,
     cashoutAmount: 0,
@@ -75,12 +81,14 @@ test('should add surcharge amount', () => {
 
 test('should add cashout amount', () => {
   const previousState: IProductState = {
+    keypadAmount: 0,
     surchargeAmount: 0,
     tipAmount: 0,
     cashoutAmount: 0,
     products: [],
   };
   expect(reducer(previousState, addCashoutAmount(105))).toEqual({
+    keypadAmount: 0,
     surchargeAmount: 0,
     tipAmount: 0,
     cashoutAmount: 105,
@@ -90,12 +98,14 @@ test('should add cashout amount', () => {
 
 test('should add tip amount', () => {
   const previousState: IProductState = {
+    keypadAmount: 0,
     surchargeAmount: 0,
     tipAmount: 0,
     cashoutAmount: 0,
     products: [],
   };
   expect(reducer(previousState, addTipAmount(105))).toEqual({
+    keypadAmount: 0,
     surchargeAmount: 0,
     tipAmount: 105,
     cashoutAmount: 0,

--- a/src/redux/reducers/ProductSlice/productSlice.ts
+++ b/src/redux/reducers/ProductSlice/productSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { IAddProductAction, IProductState } from './interfaces';
 
 const initialState: IProductState = {
+  keypadAmount: 0,
   tipAmount: 0,
   cashoutAmount: 0,
   surchargeAmount: 0,
@@ -32,10 +33,13 @@ const productSlice = createSlice({
     addCashoutAmount(state: IProductState, action: PayloadAction<number>) {
       state.cashoutAmount = action.payload;
     },
+    addKeypadAmount(state: IProductState, action: PayloadAction<number>) {
+      state.keypadAmount = action.payload;
+    },
   },
 });
 
-export const { addProduct, clearAllProducts, addCashoutAmount, addSurchargeAmount, addTipAmount } =
+export const { addProduct, clearAllProducts, addCashoutAmount, addSurchargeAmount, addTipAmount, addKeypadAmount } =
   productSlice.actions;
 
 export default productSlice.reducer;

--- a/src/redux/reducers/TerminalSlice/terminalsSliceSelectors.test.ts
+++ b/src/redux/reducers/TerminalSlice/terminalsSliceSelectors.test.ts
@@ -115,6 +115,7 @@ describe('Test terminals slice selectors', () => {
       common: { showFlowPanel: false, acquireConfirmPairingFlow: false },
       pair: { status: '' },
       products: {
+        keypadAmount: 0,
         surchargeAmount: 0,
         tipAmount: 0,
         cashoutAmount: 0,

--- a/src/services/spiService/index.ts
+++ b/src/services/spiService/index.ts
@@ -249,6 +249,8 @@ class SpiService {
           `%cspiSecretsChanged: ${JSON.stringify(instance.spiClient._secrets)}`,
           `color: ${FIELD_PRESSED_COLOR}`
         );
+
+        if (!instance.spiClient._secrets) this.removeTerminalInstance(instanceId);
       });
 
       // SPI Status Change Listener

--- a/src/utils/tests/common.tsx
+++ b/src/utils/tests/common.tsx
@@ -114,6 +114,7 @@ export const customMockPairFormParamsState = (
 });
 
 export const mockDefaultProducts = {
+  keypadAmount: 0,
   surchargeAmount: 100,
   tipAmount: 100,
   cashoutAmount: 100,


### PR DESCRIPTION
* fixed the issue of shown 0 in order finished page (Since we need to keep subtotal in one place (as single source of truth) and also keep current code structure, so I was thinking we can add one more attribute for get keypad amount state so we can differentiate the subtotal value either come from `user image selection` or `keypad input`)
* updated some unit tests and also added new unit test for new changes