### PR TITLE
Fix table retrieval and bill flow ended

### DIFF
--- a/src/pages/Table/pos.ts
+++ b/src/pages/Table/pos.ts
@@ -650,9 +650,7 @@ class TablePos extends Pos {
     });
   }
 
-  billPaymentFlowEnded(message: any) {
-    const billPaymentFlowEndedResponse = new BillPaymentFlowEndedResponse(message);
-
+  billPaymentFlowEnded(billPaymentFlowEndedResponse: any) {
     if (!this.billsStore[billPaymentFlowEndedResponse.BillId]) {
       // We cannot find this bill.
       this._flowMsg.Info(`Incorrect Bill Id!`);
@@ -709,10 +707,8 @@ class TablePos extends Pos {
       this._flowMsg.Info(`# No Open Tables.`);
     }
 
-    const openTableListJson = JSON.stringify(openTableList);
-
     return Object.assign(new GetOpenTablesResponse(), {
-      TableData: openTableListJson,
+      TableData: openTableList,
     });
   }
 


### PR DESCRIPTION
The changes that were made on the library for P@T require two small changes to the TablePOS sample. The  `billPaymentFlowEnded` handler no longer has to deal with the raw message returned from the library and the table data sent to the library no longer as to be a JSON string (only for it to be parsed back in the library again)