### PR TITLE
Feature/int 328 dynamically handle terminal printer existence

### DIFF
--- a/src/components/TerminalsPage/TerminalDetails/AboutTerminal/__snapshots__/index.test.tsx.snap
+++ b/src/components/TerminalsPage/TerminalDetails/AboutTerminal/__snapshots__/index.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`Test <AboutTerminal /> should match AboutTerminal snapshot test 1`] = `
           <p
             class="MuiTypography-root MuiTypography-body1"
           >
-            Print EFTPOS receipt
+            Print customer EFTPOS receipt
           </p>
         </div>
         <div
@@ -216,14 +216,16 @@ exports[`Test <AboutTerminal /> should match AboutTerminal snapshot test 1`] = `
             class="MuiSwitch-root"
           >
             <span
-              aria-disabled="false"
-              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-14 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+              aria-disabled="true"
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-14 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-disabled-16 Mui-disabled Mui-disabled Mui-disabled"
+              tabindex="-1"
             >
               <span
                 class="MuiIconButton-label"
               >
                 <input
                   class="PrivateSwitchBase-input-17 MuiSwitch-input"
+                  disabled=""
                   type="checkbox"
                   value=""
                 />
@@ -231,9 +233,6 @@ exports[`Test <AboutTerminal /> should match AboutTerminal snapshot test 1`] = `
                   class="MuiSwitch-thumb"
                 />
               </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
             </span>
             <span
               class="MuiSwitch-track"

--- a/src/components/TerminalsPage/TerminalDetails/AboutTerminal/__snapshots__/index.test.tsx.snap
+++ b/src/components/TerminalsPage/TerminalDetails/AboutTerminal/__snapshots__/index.test.tsx.snap
@@ -197,6 +197,50 @@ exports[`Test <AboutTerminal /> should match AboutTerminal snapshot test 1`] = `
           </p>
         </div>
       </div>
+      <div
+        class="MuiGrid-root makeStyles-detailRow-2 MuiGrid-container"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1"
+          >
+            Print EFTPOS receipt
+          </p>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
+        >
+          <span
+            class="MuiSwitch-root"
+          >
+            <span
+              aria-disabled="false"
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-14 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+            >
+              <span
+                class="MuiIconButton-label"
+              >
+                <input
+                  class="PrivateSwitchBase-input-17 MuiSwitch-input"
+                  type="checkbox"
+                  value=""
+                />
+                <span
+                  class="MuiSwitch-thumb"
+                />
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </span>
+            <span
+              class="MuiSwitch-track"
+            />
+          </span>
+        </div>
+      </div>
     </div>
     <div
       class="MuiGrid-root makeStyles-sectionSpacing-3 MuiGrid-item"

--- a/src/components/TerminalsPage/TerminalDetails/AboutTerminal/index.test.tsx
+++ b/src/components/TerminalsPage/TerminalDetails/AboutTerminal/index.test.tsx
@@ -16,6 +16,7 @@ describe('Test <AboutTerminal />', () => {
   let mockContainer: Any;
 
   beforeEach(() => {
+    spiService.spiHardwarePrinterAvailable = jest.fn().mockReturnValue(false);
     mockContainer = mockWithRedux(
       <AboutTerminal
         receiptToggle={{

--- a/src/components/TerminalsPage/TerminalDetails/AboutTerminal/index.tsx
+++ b/src/components/TerminalsPage/TerminalDetails/AboutTerminal/index.tsx
@@ -16,6 +16,7 @@ import {
   settlement,
   settlementEnquiry,
   spiSetPromptForCustomerCopyOnEftpos,
+  spiHardwarePrinterAvailable,
 } from '../../../../utils/common/terminal/terminalHelpers';
 import { IAboutTerminal } from '../interfaces';
 import useStyles from './index.styles';
@@ -104,10 +105,14 @@ export default function AboutTerminal({
           ))}
           <Grid className={classes.detailRow} container>
             <Grid item md={4} xs={12}>
-              <Typography>Print EFTPOS receipt</Typography>
+              <Typography>Print customer EFTPOS receipt</Typography>
             </Grid>
             <Grid item md={8} xs={12}>
-              <Switch checked={Boolean(promptForCustomerCopy)} onChange={onPrintReceiptToggle} />
+              <Switch
+                disabled={!spiHardwarePrinterAvailable(terminal.id)}
+                checked={Boolean(promptForCustomerCopy)}
+                onChange={onPrintReceiptToggle}
+              />
             </Grid>
           </Grid>
         </Grid>

--- a/src/components/TerminalsPage/TerminalDetails/AboutTerminal/index.tsx
+++ b/src/components/TerminalsPage/TerminalDetails/AboutTerminal/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Switch from '@material-ui/core//Switch';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
@@ -11,7 +12,11 @@ import {
 import { useAppDispatch, useAppSelector } from '../../../../redux/hooks';
 import { terminalPosRefId } from '../../../../redux/reducers/TerminalSlice/terminalsSliceSelectors';
 import { handleUnPairClick } from '../../../../utils/common/pair/pairStatusHelpers';
-import { settlement, settlementEnquiry } from '../../../../utils/common/terminal/terminalHelpers';
+import {
+  settlement,
+  settlementEnquiry,
+  spiSetPromptForCustomerCopyOnEftpos,
+} from '../../../../utils/common/terminal/terminalHelpers';
 import { IAboutTerminal } from '../interfaces';
 import useStyles from './index.styles';
 import StatusBox from './StatusBox';
@@ -41,6 +46,11 @@ export default function AboutTerminal({
     });
 
     if (!receiptToggle.settlementEnquiry) settlementEnquiry(terminal.id, posRefId as string);
+  };
+
+  const promptForCustomerCopy = terminal?.settings?.promptForCustomerCopy;
+  const onPrintReceiptToggle = () => {
+    spiSetPromptForCustomerCopyOnEftpos(terminal.id, !promptForCustomerCopy);
   };
 
   return (
@@ -92,6 +102,14 @@ export default function AboutTerminal({
               </Grid>
             </Grid>
           ))}
+          <Grid className={classes.detailRow} container>
+            <Grid item md={4} xs={12}>
+              <Typography>Print EFTPOS receipt</Typography>
+            </Grid>
+            <Grid item md={8} xs={12}>
+              <Switch checked={Boolean(promptForCustomerCopy)} onChange={onPrintReceiptToggle} />
+            </Grid>
+          </Grid>
         </Grid>
         <Grid item className={(classes.fullWidth, classes.sectionSpacing)}>
           <Typography variant="h6" component="h1">

--- a/src/components/TerminalsPage/TerminalDetails/__snapshots__/index.test.tsx.snap
+++ b/src/components/TerminalsPage/TerminalDetails/__snapshots__/index.test.tsx.snap
@@ -353,7 +353,7 @@ exports[`Test <TerminalDetails /> should match TerminalDetails snapshot tes 1`] 
                           <p
                             class="MuiTypography-root MuiTypography-body1"
                           >
-                            Print EFTPOS receipt
+                            Print customer EFTPOS receipt
                           </p>
                         </div>
                         <div
@@ -363,14 +363,16 @@ exports[`Test <TerminalDetails /> should match TerminalDetails snapshot tes 1`] 
                             class="MuiSwitch-root"
                           >
                             <span
-                              aria-disabled="false"
-                              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-45 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                              aria-disabled="true"
+                              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-45 MuiSwitch-switchBase MuiSwitch-colorSecondary PrivateSwitchBase-disabled-47 Mui-disabled Mui-disabled Mui-disabled"
+                              tabindex="-1"
                             >
                               <span
                                 class="MuiIconButton-label"
                               >
                                 <input
                                   class="PrivateSwitchBase-input-48 MuiSwitch-input"
+                                  disabled=""
                                   type="checkbox"
                                   value=""
                                 />
@@ -378,9 +380,6 @@ exports[`Test <TerminalDetails /> should match TerminalDetails snapshot tes 1`] 
                                   class="MuiSwitch-thumb"
                                 />
                               </span>
-                              <span
-                                class="MuiTouchRipple-root"
-                              />
                             </span>
                             <span
                               class="MuiSwitch-track"

--- a/src/components/TerminalsPage/TerminalDetails/__snapshots__/index.test.tsx.snap
+++ b/src/components/TerminalsPage/TerminalDetails/__snapshots__/index.test.tsx.snap
@@ -344,6 +344,50 @@ exports[`Test <TerminalDetails /> should match TerminalDetails snapshot tes 1`] 
                           </p>
                         </div>
                       </div>
+                      <div
+                        class="MuiGrid-root makeStyles-detailRow-33 MuiGrid-container"
+                      >
+                        <div
+                          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1"
+                          >
+                            Print EFTPOS receipt
+                          </p>
+                        </div>
+                        <div
+                          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
+                        >
+                          <span
+                            class="MuiSwitch-root"
+                          >
+                            <span
+                              aria-disabled="false"
+                              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-45 MuiSwitch-switchBase MuiSwitch-colorSecondary"
+                            >
+                              <span
+                                class="MuiIconButton-label"
+                              >
+                                <input
+                                  class="PrivateSwitchBase-input-48 MuiSwitch-input"
+                                  type="checkbox"
+                                  value=""
+                                />
+                                <span
+                                  class="MuiSwitch-thumb"
+                                />
+                              </span>
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </span>
+                            <span
+                              class="MuiSwitch-track"
+                            />
+                          </span>
+                        </div>
+                      </div>
                     </div>
                     <div
                       class="MuiGrid-root makeStyles-sectionSpacing-34 MuiGrid-item"
@@ -457,18 +501,18 @@ exports[`Test <TerminalDetails /> should match TerminalDetails snapshot tes 1`] 
           </div>
         </div>
         <div
-          class="MuiDrawer-root MuiDrawer-docked makeStyles-drawer-45"
+          class="MuiDrawer-root MuiDrawer-docked makeStyles-drawer-49"
           data-test-id="flowPanel"
         >
           <div
-            class="MuiPaper-root MuiDrawer-paper makeStyles-drawerPaper-46 MuiDrawer-paperAnchorRight MuiDrawer-paperAnchorDockedRight MuiPaper-elevation0"
+            class="MuiPaper-root MuiDrawer-paper makeStyles-drawerPaper-50 MuiDrawer-paperAnchorRight MuiDrawer-paperAnchorDockedRight MuiPaper-elevation0"
             style="visibility: hidden; webkit-transform: translateX(1024px) translateX(0px); transform: translateX(1024px) translateX(0px);"
           >
             <div
-              class="MuiBox-root MuiBox-root-50 makeStyles-flowBoxWrapper-47"
+              class="MuiBox-root MuiBox-root-54 makeStyles-flowBoxWrapper-51"
             >
               <div
-                class="MuiBox-root MuiBox-root-51 makeStyles-flowBox-48"
+                class="MuiBox-root MuiBox-root-55 makeStyles-flowBox-52"
               >
                 <h1
                   class="MuiTypography-root MuiTypography-h6"
@@ -476,7 +520,7 @@ exports[`Test <TerminalDetails /> should match TerminalDetails snapshot tes 1`] 
                   Flow
                 </h1>
                 <pre
-                  class="makeStyles-flowContent-49"
+                  class="makeStyles-flowContent-53"
                 >
                   
 # ----------- STATUS -----------

--- a/src/components/TerminalsPage/TerminalDetails/index.test.tsx
+++ b/src/components/TerminalsPage/TerminalDetails/index.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent } from '@testing-library/react';
 import TerminalDetails from '.';
 import { ITerminalState } from '../../../redux/reducers/TerminalSlice/interfaces';
 import { terminalInstance } from '../../../redux/reducers/TerminalSlice/terminalsSliceSelectors';
+import spiService from '../../../services/spiService';
 import mockWithRedux, { mockTerminalInstanceId, pairedMockTerminals } from '../../../utils/tests/common';
 
 jest.mock('react-router-dom', () => ({
@@ -13,6 +14,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 function setupContainer(terminals: ITerminalState = pairedMockTerminals) {
+  spiService.spiHardwarePrinterAvailable = jest.fn().mockReturnValue(false);
   const customizedStore = {
     getState: () => ({
       common: {},

--- a/src/redux/reducers/TerminalSlice/interfaces/index.ts
+++ b/src/redux/reducers/TerminalSlice/interfaces/index.ts
@@ -33,7 +33,7 @@ export interface ITerminal {
 }
 
 export interface ISettings {
-  eftposReceipt: boolean;
+  promptForCustomerCopy: boolean;
   sigFlow: boolean;
   printMerchantCopy: boolean;
   suppressMerchantPassword: boolean;
@@ -177,7 +177,7 @@ export interface IUpdateTxFlowAction {
 }
 export interface IUpdateSettingAction {
   id: string;
-  settings: ISettings;
+  settings: Partial<ISettings>;
 }
 
 export interface IConfigurations {

--- a/src/redux/reducers/TerminalSlice/terminalsSlice.test.ts
+++ b/src/redux/reducers/TerminalSlice/terminalsSlice.test.ts
@@ -570,7 +570,7 @@ test('should handle updateTxFlow for empty state', () => {
 test('should handle updateSetting', () => {
   // Arrange
   const mockSettings = {
-    eftposReceipt: true,
+    promptForCustomerCopy: true,
     sigFlow: true,
     printMerchantCopy: true,
     suppressMerchantPassword: true,
@@ -597,7 +597,7 @@ test('should handle updateSetting for empty state', () => {
   // Arrange
   const previousState = {};
   const mockSettings = {
-    eftposReceipt: true,
+    promptForCustomerCopy: true,
     sigFlow: true,
     printMerchantCopy: true,
     suppressMerchantPassword: true,

--- a/src/redux/reducers/TerminalSlice/terminalsSlice.ts
+++ b/src/redux/reducers/TerminalSlice/terminalsSlice.ts
@@ -7,6 +7,7 @@ import {
   IClearTransactionAction,
   IConfigurations,
   IRemoveTerminalAction,
+  ISettings,
   ITerminalState,
   IUpdateDeviceAddressAction,
   IUpdatePairingFlowAction,
@@ -90,8 +91,7 @@ const terminalsSlice = createSlice({
     updateSetting(state: ITerminalState, action: PayloadAction<IUpdateSettingAction>) {
       const { id, settings } = action.payload;
       const currentState = state[id] || {};
-
-      currentState.settings = settings;
+      currentState.settings = { ...(currentState.settings as ISettings), ...settings };
       state[id] = currentState;
     },
 

--- a/src/services/spiService/index.test.ts
+++ b/src/services/spiService/index.test.ts
@@ -410,4 +410,46 @@ describe('Test SpiService functionalities', () => {
     // Assert
     expect(mockSetTerminalIdle).toHaveBeenCalled();
   });
+
+  test('hardware printer is available', () => {
+    // Arrange
+    mockSpiClient.GetHardwarePrinterAvailable = () => true;
+    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+      spiClient: mockSpiClient,
+    });
+
+    // Act
+    const result = spiService.spiHardwarePrinterAvailable(mockTerminalInstanceId);
+
+    // Assert
+    expect(result).toEqual(true);
+  });
+
+  test('hardware printer is not available', () => {
+    // Arrange
+    mockSpiClient.GetHardwarePrinterAvailable = () => false;
+    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+      spiClient: mockSpiClient,
+    });
+
+    // Act
+    const result = spiService.spiHardwarePrinterAvailable(mockTerminalInstanceId);
+
+    // Assert
+    expect(result).toEqual(false);
+  });
+
+  test('hardware printer is not available when spi instance is undefined', () => {
+    // Arrange
+    mockSpiClient.GetHardwarePrinterAvailable = () => false;
+    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+      spiClient: undefined,
+    });
+
+    // Act
+    const result = spiService.spiHardwarePrinterAvailable(mockTerminalInstanceId);
+
+    // Assert
+    expect(result).toEqual(false);
+  });
 });

--- a/src/services/spiService/index.ts
+++ b/src/services/spiService/index.ts
@@ -12,6 +12,7 @@ import { readTerminalPairError, updatePairFormParams } from '../../redux/reducer
 import {
   updatePairingFlow,
   updatePairingStatus,
+  updateSetting,
   updateTerminal,
   updateTerminalBatteryLevel,
   updateTerminalConfigurations,
@@ -110,7 +111,16 @@ class SpiService {
         Object.keys(terminalsStorage).indexOf(instanceId) > -1 ? terminalsStorage[instanceId] : pairForm;
 
       // get current terminal settings
-      const { acquirerCode, autoAddress, deviceAddress, posId, serialNumber, testMode, secrets } = terminalFormParams;
+      const {
+        acquirerCode,
+        autoAddress,
+        deviceAddress,
+        posId,
+        serialNumber,
+        testMode,
+        secrets,
+        promptForCustomerCopy,
+      } = terminalFormParams;
 
       // create localStorage instance if no terminal instance has been found inside current local terminals storage
       if (Object.keys(terminalsStorage).indexOf(instanceId) <= -1) {
@@ -122,12 +132,13 @@ class SpiService {
           })
         );
       }
-
+      console.log(`promptForCustomerCopy ${promptForCustomerCopy}`);
       // save acquirerCode & posId & serialNumber & testMode into localStorage
       this.updateTerminalStorage(instanceId, 'acquirerCode', acquirerCode);
       this.updateTerminalStorage(instanceId, 'posId', posId);
       this.updateTerminalStorage(instanceId, 'serialNumber', serialNumber);
       this.updateTerminalStorage(instanceId, 'testMode', testMode);
+      this.updateTerminalStorage(instanceId, 'promptForCustomerCopy', promptForCustomerCopy);
 
       if (!autoAddress) this.updateTerminalStorage(instanceId, 'deviceAddress', deviceAddress);
 
@@ -153,10 +164,11 @@ class SpiService {
           this.handleTerminalPairFailure(instanceId);
         }
 
-        // setup AUTO address to show in current pair form
+        // setup AUTO address to show in current p air form
         instance.spiClient.SetEftposAddress(eftposAddress);
       }
 
+      instance.spiClient.Config.PromptForCustomerCopyOnEftpos = promptForCustomerCopy;
       instance.spiClient.PrintingResponse = () => true;
       instance.currentTxFlowStateOverride = null; // without mutating spi client's tx flow object.
 
@@ -288,7 +300,14 @@ class SpiService {
           pairingFlow: spiClient?.CurrentPairingFlowState,
           posVersion: spiClient?._posVersion,
           secrets: spiClient?._secrets,
-          settings: null, // not available during pair terminal stage
+          settings: {
+            promptForCustomerCopy,
+            sigFlow: false,
+            printMerchantCopy: false,
+            suppressMerchantPassword: false,
+            receiptHeader: null,
+            receiptFooter: null,
+          },
           status: spiClient?._currentStatus,
           terminalStatus: spiClient?.CurrentFlow,
           txFlow: getTxFlow(spiClient?.CurrentTxFlowState),
@@ -496,6 +515,17 @@ class SpiService {
   spiSetTerminalToIdle(instanceId: string) {
     const spi = this.readTerminalInstance(instanceId).spiClient;
     spi.AckFlowEndedAndBackToIdle();
+  }
+
+  spiSetPromptForCustomerCopyOnEftpos(instanceId: string, value: boolean) {
+    // set in spi lib
+    const spi = this.readTerminalInstance(instanceId).spiClient;
+    spi.Config.PromptForCustomerCopyOnEftpos = value;
+    // set in redux
+    const settings = { promptForCustomerCopy: value };
+    this.dispatchAction(updateSetting({ id: instanceId, settings }));
+    // set in browser storage
+    this.updateTerminalStorage(instanceId, 'promptForCustomerCopy', value);
   }
 
   initiatePurchaseTransaction(

--- a/src/services/spiService/index.ts
+++ b/src/services/spiService/index.ts
@@ -528,6 +528,11 @@ class SpiService {
     this.updateTerminalStorage(instanceId, 'promptForCustomerCopy', value);
   }
 
+  spiHardwarePrinterAvailable(instanceId: string) {
+    const spi = this.readTerminalInstance(instanceId).spiClient;
+    return Boolean(spi?.GetHardwarePrinterAvailable());
+  }
+
   initiatePurchaseTransaction(
     instanceId: string,
     posRefId: string,

--- a/src/utils/common/terminal/terminalHelpers.ts
+++ b/src/utils/common/terminal/terminalHelpers.ts
@@ -19,3 +19,7 @@ export function declineSignature(instanceId: string): void {
 export function spiSetPromptForCustomerCopyOnEftpos(instanceId: string, value: boolean): void {
   spiService.spiSetPromptForCustomerCopyOnEftpos(instanceId, value);
 }
+
+export function spiHardwarePrinterAvailable(instanceId: string): boolean {
+  return spiService.spiHardwarePrinterAvailable(instanceId);
+}

--- a/src/utils/common/terminal/terminalHelpers.ts
+++ b/src/utils/common/terminal/terminalHelpers.ts
@@ -15,3 +15,7 @@ export function approveSignature(instanceId: string): void {
 export function declineSignature(instanceId: string): void {
   spiService.signatureForDecline(instanceId);
 }
+
+export function spiSetPromptForCustomerCopyOnEftpos(instanceId: string, value: boolean): void {
+  spiService.spiSetPromptForCustomerCopyOnEftpos(instanceId, value);
+}

--- a/src/utils/tests/common.tsx
+++ b/src/utils/tests/common.tsx
@@ -127,6 +127,7 @@ export const mockDefaultProducts = {
 
 export const defaultMockTerminals = {
   [mockTerminalInstanceId]: {
+    spiHardwarePrinterAvailable: (): boolean => false,
     acquirerCode: 'test',
     autoAddress: false,
     deviceAddress: defaultLocalIP,
@@ -281,6 +282,7 @@ export const mockSpiClient = {
   _mostRecentPongReceived: true,
   GetTerminalAddress: (): string => '',
   GetTerminalStatus: (): string => defaultAAR,
+  GetHardwarePrinterAvailable: (): boolean => false,
   SetEventBus: jest.fn(),
   BatteryLevelChanged: jest.fn(),
 };

--- a/src/utils/tests/common.tsx
+++ b/src/utils/tests/common.tsx
@@ -82,6 +82,7 @@ export const defaultMockPairFormParams = {
     isValid: true,
   },
   testMode: true,
+  promptForCustomerCopy: false,
 };
 
 export const customMockPairFormParamsState = (


### PR DESCRIPTION
TODO: increment SPI library version in package.json

### What
Added dynamic reading of a terminal to see if it has a printer. Add a toggle to switch printing on and off for customer receipt.

### Why
Before this PR, SPI library had hardcoded values to say which terminals have printers. We want to reduce the number of library changes because it is hard to get POS's to upgrade the SPI library. We may support new terminals in the future. POS's may also want to create UI surrounding this information.

### How
Read SPI library to check if the terminal has a printer. If it doesn't set the toggle to disabled. If it does, allow the merchant to toggle printing from the terminal settings page. The toggle value is stored in the browser storage, SPI library and espressoPOS app memory (redux).

### Jira
https://mx51.atlassian.net/browse/INTG-328