### PR TITLE
Update manifest and temporarily hide preauth page

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,13 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.7] - 2023-8-17
 
 ### Added
 
 - [INTG-506](https://mx51.atlassian.net/browse/INTG-506) Changelog file
 - [INTG-522](https://mx51.atlassian.net/browse/INTG-522) Pairing record is missing when terminal is disconnected
-- [INTG-573](https://mx51.atlassian.net/browse/INTG-573) Migrate MotelPOS pre-auth transaction flows to EspressoPOS
 - [INTG-544](https://mx51.atlassian.net/browse/INTG-544) View the version of EspressoPOS
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spi-sample-pos-2",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "private": true,
   "engines": {
     "node": ">=16"
@@ -31,6 +31,7 @@
     "dev": "NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
     "build": "NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
     "test": "tsc && react-scripts test --watchAll=false",
+    "test:watch": "react-scripts test",
     "test:deploy": "npm test -- --reporters=jest-junit --reporters=default --coverage --coverageReporters=cobertura --coverageReporters=html",
     "test:coverage": "react-scripts test --env=jsdom --watchAll=false --coverage",
     "eject": "react-scripts eject",

--- a/src/definitions/constants/menuItemsConfigs.tsx
+++ b/src/definitions/constants/menuItemsConfigs.tsx
@@ -40,11 +40,11 @@ export default {
       path: PATH_CASH_OUT,
       icon: <IconCashout />,
     },
-    {
-      name: TEXT_PRE_AUTH,
-      path: PATH_PRE_AUTH,
-      icon: <IconPreAuth />,
-    },
+    // {
+    //   name: TEXT_PRE_AUTH,
+    //   path: PATH_PRE_AUTH,
+    //   icon: <IconPreAuth />,
+    // },
   ],
   terminals: [
     {

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -4,7 +4,7 @@ import Loading from '../components/Loading';
 import {
   PATH_PAIR,
   PATH_PAY_NOW,
-  PATH_PRE_AUTH,
+  // PATH_PRE_AUTH,
   PATH_PURCHASE,
   PATH_REFUND,
   PATH_TERMINALS,
@@ -14,7 +14,7 @@ import {
 } from '../definitions/constants/routerConfigs';
 
 const Pair = React.lazy(() => import('../components/PairPage'));
-const PreAuth = React.lazy(() => import('../components/PreAuthPage'));
+// const PreAuth = React.lazy(() => import('../components/PreAuthPage'));
 const Purchase = React.lazy(() => import('../components/PurchasePage'));
 const Refund = React.lazy(() => import('../components/RefundPage'));
 const Terminals = React.lazy(() => import('../components/TerminalsPage'));
@@ -30,7 +30,7 @@ const AppRoutes = (): React.ReactElement => (
     <Suspense fallback={<Loading />}>
       <Switch>
         <Route exact path={PATH_PAIR} component={Pair} />
-        <Route exact path={PATH_PRE_AUTH} component={PreAuth} />
+        {/* <Route exact path={PATH_PRE_AUTH} component={PreAuth} /> */}
         <Route exact path={PATH_PURCHASE} component={Purchase} />
         <Route exact path={PATH_REFUND} component={Refund} />
         <Route exact path={PATH_TERMINALS} component={Terminals} />


### PR DESCRIPTION
@jwsandeman  MJ requires us to exclude the pre-auth stuff when releasing the 1.2.7 version of Espresso. We will bring this back in 1.2.8