### PR TITLE
INTG-803, INTG-784 Address QA feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spi-sample-pos-2",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "spi-sample-pos-2",
-      "version": "1.7.5",
+      "version": "1.7.6",
       "dependencies": {
         "@material-ui/core": "^4.12.1",
         "@material-ui/icons": "^4.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spi-sample-pos-2",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "private": true,
   "engines": {
     "node": ">=16"

--- a/src/components/OrderFinished/OrderFinished.tsx
+++ b/src/components/OrderFinished/OrderFinished.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Grid } from '@material-ui/core';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import selectedTerminalIdSelector from '../../redux/reducers/SelectedTerminalSlice/selectedTerminalSliceSelector';
 import { ITerminalProps } from '../../redux/reducers/TerminalSlice/interfaces';
 import {
@@ -12,11 +12,17 @@ import Layout from '../Layout';
 import PurchaseFlow from '../PurchaseFlow';
 import { PaymentSummary } from '../PaymentSummary/PaymentSummary';
 import { TxLogServiceMapper } from '../../services/txLogService';
+import { clearAllProducts } from '../../redux/reducers/ProductSlice/productSlice';
 
 function OrderFinished(): React.ReactElement {
   const selectedTerminal = useSelector(selectedTerminalIdSelector);
   const currentTerminal = useSelector(terminalInstance(selectedTerminal)) as ITerminalProps;
   const { typePath } = useSelector(terminalTransactionTypeObject(selectedTerminal));
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(clearAllProducts());
+  }, []);
 
   if (!currentTerminal?.txFlow) return <div>Could not load transaction.</div>;
 

--- a/src/components/PaymentSummary/PaymentSummary.tsx
+++ b/src/components/PaymentSummary/PaymentSummary.tsx
@@ -1,7 +1,6 @@
 import { Box, Button, Container, Grid } from '@material-ui/core';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useHistory } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
 import { TxLogItem } from '../../services/txLogService';
 import { useTransactionDetailPageStyle } from '../TransactionPage/TransactionDetailsPage/TransactionDetailsPage.style';
 import { OrderStatus } from './OrderStatus';
@@ -12,7 +11,6 @@ import { PATH_TRANSACTIONS } from '../../definitions/constants/routerConfigs';
 import { OrderInfo } from './OrderInfo';
 import { SplitSummary } from './SplitSummary';
 import { OrderButtons } from './OrderButtons';
-import { clearAllProducts } from '../../redux/reducers/ProductSlice/productSlice';
 
 type Props = {
   currentTransaction: TxLogItem;
@@ -34,15 +32,10 @@ export const PaymentSummary = ({ currentTransaction, transactionHistory, splitTr
   const classes = useTransactionDetailPageStyle();
   const { receipt, hostResponseText } = currentTransaction;
   const history = useHistory();
-  const dispatch = useDispatch();
 
   const goToTransactions = (path: string) => {
     history.push(path);
   };
-
-  useEffect(() => {
-    dispatch(clearAllProducts());
-  }, []);
 
   const isCashoutOnly = currentTransaction?.type === 'CashoutOnly';
 
@@ -67,7 +60,7 @@ export const PaymentSummary = ({ currentTransaction, transactionHistory, splitTr
                   splitAmount={splitTransaction.splitAmount}
                   outstandingAmount={splitTransaction.outstandingAmount}
                   splitIndex={splitTransaction.splitIndex}
-                  splitMode="splitEvenly"
+                  splitMode={splitTransaction.splitMode}
                   numberOfSplits={splitTransaction.numberOfSplits}
                 />
               ) : (

--- a/src/components/PaymentSummary/SplitSummary.tsx
+++ b/src/components/PaymentSummary/SplitSummary.tsx
@@ -17,7 +17,7 @@ export const SplitSummary = ({ splitAmount, outstandingAmount, splitIndex, split
   return (
     <Box className={classes.paper} component={Paper}>
       <span className={classes.splitIndexRow}>
-        Split {splitIndex + 1} {splitMode === 'splitEvenly' && `of ${numberOfSplits}`}
+        Split #{splitIndex + 1} {splitMode === 'splitEvenly' && `of ${numberOfSplits}`}
       </span>
       {currencyFormat(splitAmount / 100)}
       <Box className={classes.outstandingAmountRow}>


### PR DESCRIPTION
This PRs are raised to address QA feedback of  https://mx51.atlassian.net/browse/INTG-803 and https://mx51.atlassian.net/browse/INTG-784.


Issue 1 : The order line items were deleted after the first payment in a split transaction.

Context: We render `SplitReceiptPanel` after a successful split, the `SplitReceiptPanel` is then rendered the `PaymentSummary`  ( SplitReceiptPanel > PaymentSummary ). Inside the PaymentSummary, there is a useEffect hook to clear all the products as soon as the component is rendered.  So the solution is to simply remove this logic in the `PaymentSummary` component. 

Issue 2:  Split summary is displayed incorrectly when splitting by amount. 

Context: We have 2 ways of splitting i.e Split by amount and split evenly. When splitting evenly, we display it as `Split #1 of 2 ` or `Split #2 of 2`. When splitting by amount, we simply display it as `Split #2`, `Split #3`.  The issue is that we forgot to pass `splitMode` to the `SplitSummary` component. 

