### PR TITLE
ITNG-962 Fix terminals and persist:terminal out of sync causing a bro…

### DIFF
--- a/src/components/PairPage/PairPage.tsx
+++ b/src/components/PairPage/PairPage.tsx
@@ -42,7 +42,7 @@ const PairPage: React.FC = () => {
           option: currentTerminal.acquirerCode,
         },
         deviceAddress: {
-          value: currentTerminal.deviceAddress.split('//')[1],
+          value: currentTerminal.deviceAddress,
           isValid: true,
         },
         posId: {

--- a/src/components/TerminalsPage/TerminalDetails/AboutTerminal/AboutTerminal.test.tsx
+++ b/src/components/TerminalsPage/TerminalDetails/AboutTerminal/AboutTerminal.test.tsx
@@ -69,7 +69,7 @@ describe('Test <AboutTerminal />', () => {
     const handleUnPairClick = jest.fn();
     const terminalDetailsUnpairBtnDOM = mockContainer.querySelector('[data-test-id="terminalDetailsUnpairBtn"]');
 
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         Unpair: jest.fn(),
@@ -82,7 +82,7 @@ describe('Test <AboutTerminal />', () => {
 
     // Assert
     expect(handleUnPairClick).toBeDefined();
-    expect(spiService.readTerminalInstance(mockTerminalInstanceId).spiClient.Unpair).toBeCalled();
+    expect(spiService.readSpiInstance(mockTerminalInstanceId).spiClient.Unpair).toBeCalled();
   });
 
   test('should toggle settlement panel when clicked settlement button', () => {
@@ -91,7 +91,7 @@ describe('Test <AboutTerminal />', () => {
     const terminalDetailsSettlementBtnDOM = mockContainer.querySelector(
       '[data-test-id="terminalDetailsSettlementBtn"]'
     );
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         InitiateSettleTx: jest.fn(),
@@ -104,7 +104,7 @@ describe('Test <AboutTerminal />', () => {
 
     // Assert
     expect(handleSettlementDisplay).toBeDefined();
-    expect(spiService.readTerminalInstance(mockTerminalInstanceId).spiClient.InitiateSettleTx).toBeCalled();
+    expect(spiService.readSpiInstance(mockTerminalInstanceId).spiClient.InitiateSettleTx).toBeCalled();
   });
 
   test('should toggle settlementEnquiry panel when clicked settlementEnquiry button', () => {
@@ -113,7 +113,7 @@ describe('Test <AboutTerminal />', () => {
     const terminalDetailsSettlementEnquiryBtnBtnDOM = mockContainer.querySelector(
       '[data-test-id="terminalDetailsSettlementEnquiryBtn"]'
     );
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         InitiateSettlementEnquiry: jest.fn(),
@@ -126,7 +126,7 @@ describe('Test <AboutTerminal />', () => {
 
     // Assert
     expect(handleSettlementEnquiryDisplay).toBeDefined();
-    expect(spiService.readTerminalInstance(mockTerminalInstanceId).spiClient.InitiateSettlementEnquiry).toBeCalled();
+    expect(spiService.readSpiInstance(mockTerminalInstanceId).spiClient.InitiateSettlementEnquiry).toBeCalled();
   });
 
   test('should call settlement() when settlement value is true', () => {
@@ -148,7 +148,7 @@ describe('Test <AboutTerminal />', () => {
     const terminalDetailsSettlementBtnDOM = newMockContainer.querySelector(
       '[data-test-id="terminalDetailsSettlementBtn"]'
     );
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         InitiateSettleTx: jest.fn(),
@@ -182,7 +182,7 @@ describe('Test <AboutTerminal />', () => {
     const terminalDetailsSettlementEnquiryBtnBtnDOM = newMockContainer.querySelector(
       '[data-test-id="terminalDetailsSettlementEnquiryBtn"]'
     );
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         InitiateSettlementEnquiry: jest.fn(),

--- a/src/redux/reducers/TerminalSlice/interfaces/index.ts
+++ b/src/redux/reducers/TerminalSlice/interfaces/index.ts
@@ -22,6 +22,7 @@ export interface ITerminalProps {
   terminalStatus: string | null;
   txFlow: ITxFlow | null;
   txMessage: ITxMessage | null;
+  environment?: string;
 }
 
 export interface ITerminalState {
@@ -183,7 +184,7 @@ export interface IUpdateTerminalSerialNumberAction {
 }
 export interface IUpdateTerminalSecretAction {
   id: string;
-  secrets: ISecrets;
+  secrets: ISecrets | null;
 }
 export interface IClearTransactionAction {
   id: string;

--- a/src/redux/reducers/TerminalSlice/terminalsSlice.ts
+++ b/src/redux/reducers/TerminalSlice/terminalsSlice.ts
@@ -1,6 +1,6 @@
-import { SpiStatus, SuccessState, TransactionType } from '@mx51/spi-client-js';
+import { SpiStatus, SuccessState } from '@mx51/spi-client-js';
 import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit';
-import { SPI_PAIR_STATUS, messageEvents } from '../../../definitions/constants/commonConfigs';
+import { SPI_PAIR_STATUS } from '../../../definitions/constants/commonConfigs';
 import {
   IAddTerminalAction,
   IBatteryLevel,
@@ -26,6 +26,9 @@ const terminalsSlice = createSlice({
   name: 'terminals',
   initialState: {},
   reducers: {
+    resetTerminalsSlice() {
+      return {};
+    },
     addTerminal(state: ITerminalState, action: PayloadAction<IAddTerminalAction>) {
       const { id, terminalConfigs } = action.payload;
 
@@ -253,6 +256,7 @@ export const {
   updateTxFlowSettlementResponse,
   updateTxFlow,
   updateTxMessage,
+  resetTerminalsSlice,
 } = terminalsSlice.actions;
 
 export default terminalsSlice.reducer;

--- a/src/services/spiService/index.test.ts
+++ b/src/services/spiService/index.test.ts
@@ -5,7 +5,6 @@ import { defaultLocalIP } from '../../definitions/constants/spiConfigs';
 import { updatePairingStatus } from '../../redux/reducers/TerminalSlice/terminalsSlice';
 import { setLocalStorage } from '../../utils/common/spi/common';
 import {
-  defaultMockPairFormParams,
   mockCashoutAmount,
   mockPosRefId,
   mockPromptForCashout,

--- a/src/services/spiService/index.test.ts
+++ b/src/services/spiService/index.test.ts
@@ -46,7 +46,7 @@ describe('Test SpiService functionalities', () => {
 
   test('test function getCurrentTxFlow()', () => {
     // Act
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: mockSpiClient,
       currentTxFlowStateOverride: null,
     });
@@ -60,7 +60,7 @@ describe('Test SpiService functionalities', () => {
 
   test('test function getTerminalStatus()', () => {
     // Act
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: mockSpiClient,
     });
     spiService.ready = jest.fn().mockReturnValue(true);
@@ -75,7 +75,7 @@ describe('Test SpiService functionalities', () => {
   test('test function ready()', async () => {
     // Act
     spiService.getCurrentStatus = jest.fn().mockReturnValue(SPI_PAIR_STATUS.PairedConnecting);
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         BatteryLevelChanged: jest.fn(),
@@ -91,7 +91,7 @@ describe('Test SpiService functionalities', () => {
 
   test('test function getCurrentStatus()', () => {
     // Act
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         BatteryLevelChanged: jest.fn(),
@@ -109,7 +109,7 @@ describe('Test SpiService functionalities', () => {
     // Arrange
     const mockAddress = 'address string';
     // Act
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: mockSpiClient,
     });
 
@@ -121,37 +121,13 @@ describe('Test SpiService functionalities', () => {
     expect(addressString).toEqual(mockAddress);
   });
 
-  test('test function updateTerminalStorage()', () => {
-    // Arrange
-    const deviceAddressKey = 'deviceAddress';
-    const deviceAddressValue = defaultLocalIP;
-
+  test('test function readSpiInstance()', () => {
     // Act
-    spiService.readTerminalList = jest.fn().mockReturnValue({});
-
-    const mockUpdateTerminalStorage = jest.spyOn(spiService, 'updateTerminalStorage');
-    spiService.updateTerminalStorage(mockTerminalInstanceId, deviceAddressKey, deviceAddressValue);
+    const mockReadSpiInstance = jest.spyOn(spiService, 'readSpiInstance');
+    spiService.readSpiInstance(mockTerminalInstanceId);
 
     // Assert
-    expect(mockUpdateTerminalStorage).toHaveBeenCalled();
-  });
-
-  test('test function readTerminalInstance()', () => {
-    // Act
-    const mockReadTerminalInstance = jest.spyOn(spiService, 'readTerminalInstance');
-    spiService.readTerminalInstance(mockTerminalInstanceId);
-
-    // Assert
-    expect(mockReadTerminalInstance).toHaveBeenCalled();
-  });
-
-  test('test function readTerminalList()', () => {
-    // Act
-    const mockReadTerminalList = jest.spyOn(spiService, 'readTerminalList');
-    spiService.readTerminalList();
-
-    // Assert
-    expect(mockReadTerminalList).toHaveBeenCalled();
+    expect(mockReadSpiInstance).toHaveBeenCalled();
   });
 
   test('test function createLibraryInstance()', async () => {
@@ -174,10 +150,7 @@ describe('Test SpiService functionalities', () => {
       })
     );
 
-    // Act
-    spiService.readTerminalList();
-
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         GetTerminalAddress: () => defaultLocalIP,
@@ -233,24 +206,15 @@ describe('Test SpiService functionalities', () => {
   test('test function spiTerminalPair()', async () => {
     // Act
     const mockSpiTerminalPair = jest.spyOn(spiService, 'spiTerminalPair');
-    const mockPairForm = {
-      acquirerCode: defaultMockPairFormParams.acquirerCode.value,
-      autoAddress: false,
-      deviceAddress: defaultMockPairFormParams.deviceAddress.value,
-      posId: defaultMockPairFormParams.posId.value,
-      serialNumber: defaultMockPairFormParams.serialNumber.value,
-      testMode: defaultMockPairFormParams.testMode,
-      secrets: null,
-    };
 
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         Pair: jest.fn(),
       },
     });
 
-    await spiService.spiTerminalPair(mockTerminalInstanceId, mockPairForm);
+    await spiService.spiTerminalPair(mockTerminalInstanceId);
 
     // Assert
     expect(mockSpiTerminalPair).toHaveBeenCalled();
@@ -260,7 +224,7 @@ describe('Test SpiService functionalities', () => {
     // Act
     const mockSpiTerminalCancelPair = jest.spyOn(spiService, 'spiTerminalCancelPair');
 
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         PairingCancel: jest.fn(),
@@ -277,7 +241,7 @@ describe('Test SpiService functionalities', () => {
     // Act
     const mockSpiTerminalUnPair = jest.spyOn(spiService, 'spiTerminalUnPair');
 
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         Unpair: jest.fn(),
@@ -295,7 +259,7 @@ describe('Test SpiService functionalities', () => {
     const mockInitTxSettlement = jest.spyOn(spiService, 'initTxSettlement');
 
     // Act
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         InitiateSettleTx: jest.fn(),
@@ -313,7 +277,7 @@ describe('Test SpiService functionalities', () => {
     const mockInitTxSettlementEnquiry = jest.spyOn(spiService, 'initTxSettlementEnquiry');
 
     // Act
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         InitiateSettlementEnquiry: jest.fn(),
@@ -331,7 +295,7 @@ describe('Test SpiService functionalities', () => {
     const mockInitTxPurchase = jest.spyOn(spiService, 'initiatePurchaseTransaction');
 
     // Act
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         InitiatePurchaseTxV2: jest.fn(),
@@ -357,7 +321,7 @@ describe('Test SpiService functionalities', () => {
     const mockInitTxMoto = jest.spyOn(spiService, 'initiateMotoPurchaseTransaction');
 
     // Act
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         InitiateMotoPurchaseTx: jest.fn(),
@@ -380,7 +344,7 @@ describe('Test SpiService functionalities', () => {
     const mockCancelTransaction = jest.spyOn(spiService, 'spiCancelTransaction');
 
     // Act
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         CancelTransaction: jest.fn(),
@@ -398,7 +362,7 @@ describe('Test SpiService functionalities', () => {
     const mockSetTerminalIdle = jest.spyOn(spiService, 'spiSetTerminalToIdle');
 
     // Act
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         AckFlowEndedAndBackToIdle: jest.fn(),

--- a/src/utils/common/pair/pairStatusHelpers.test.ts
+++ b/src/utils/common/pair/pairStatusHelpers.test.ts
@@ -4,6 +4,8 @@ import { defaultLocalIP } from '../../../definitions/constants/spiConfigs';
 import spiService from '../../../services/spiService';
 import { defaultMockPairFormParams, mockTerminalInstance, mockTerminalInstanceId } from '../../tests/common';
 import { handleCancelPairClick, handlePairClick, handleUnPairClick } from './pairStatusHelpers';
+import { store } from '../../../redux/store';
+import { resetTerminalsSlice } from '../../../redux/reducers/TerminalSlice/terminalsSlice';
 
 const mockPairSettings = {
   provider: { isValid: true, option: TEXT_FORM_DEFAULT_VALUE, value: 'test' },
@@ -15,10 +17,12 @@ const mockPairSettings = {
 };
 
 describe('Test pairStatusHelpers functions', () => {
-  const dispatch = jest.fn();
   const mockInstanceId = mockPairSettings.serialNumber.value;
 
   afterEach(cleanup);
+  afterAll(() => {
+    store.dispatch(resetTerminalsSlice());
+  });
 
   test('test handlePairClick()', () => {
     // Arrange
@@ -31,20 +35,21 @@ describe('Test pairStatusHelpers functions', () => {
       testMode: defaultMockPairFormParams.testMode,
       secrets: null,
     };
+
     // Act
-    handlePairClick(dispatch, mockPairForm);
+    handlePairClick(store.dispatch, mockPairForm);
 
     spiService.dispatchAction = jest.fn();
     spiService.createLibraryInstance = jest.fn().mockImplementationOnce(() => mockTerminalInstance);
     spiService.createLibraryInstance(mockInstanceId);
 
-    // Assert
+    // // Assert
     expect(spiService.createLibraryInstance).toHaveBeenCalledTimes(1);
   });
 
   test('test handleCancelPairClick()', () => {
     // Act
-    handleCancelPairClick(dispatch, mockTerminalInstanceId);
+    handleCancelPairClick(store.dispatch, mockTerminalInstanceId);
 
     spiService.spiTerminalCancelPair = jest.fn();
     spiService.spiTerminalCancelPair(mockInstanceId);
@@ -55,7 +60,7 @@ describe('Test pairStatusHelpers functions', () => {
 
   test('test handleUnPairClick()', () => {
     // Act
-    handleUnPairClick(dispatch, mockTerminalInstanceId);
+    handleUnPairClick(store.dispatch, mockTerminalInstanceId);
 
     spiService.spiTerminalUnPair = jest.fn();
     spiService.spiTerminalUnPair(mockInstanceId);

--- a/src/utils/common/pair/pairStatusHelpers.ts
+++ b/src/utils/common/pair/pairStatusHelpers.ts
@@ -23,19 +23,18 @@ async function handlePairClick(dispatch: AppDispatch, pairFormValues: IPairFormV
     id: instanceId,
     pairingFlow: null,
     posVersion: '',
-    secrets: pairFormValues?.secrets,
+    secrets: null,
     settings: null, // not available during pair terminal stage
     status: SPI_PAIR_STATUS.Unpaired,
     terminalStatus: '',
     txFlow: null,
     txMessage: null, // not available during pair terminal stage
+    environment: pairFormValues?.environment,
   };
 
   dispatch(addTerminal({ id: instanceId, terminalConfigs }));
   // start pairing
-  spiService.spiTerminalPair(instanceId, pairFormValues);
-  // update terminal connection status when starting to pair a terminal
-  dispatch(updatePairingStatus({ id: instanceId, status: SPI_PAIR_STATUS.PairedConnecting }));
+  spiService.spiTerminalPair(instanceId);
 }
 
 // cancel terminal pairing

--- a/src/utils/common/purchase/purchaseHelper.test.ts
+++ b/src/utils/common/purchase/purchaseHelper.test.ts
@@ -16,7 +16,7 @@ describe('Test purchaseHelper()', () => {
 
   test('should initiatePurchase() be defined when calling initiatePurchaseTransaction() function', () => {
     // Arrange
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         initiatePurchase: jest.fn(),
@@ -40,7 +40,7 @@ describe('Test purchaseHelper()', () => {
   });
   test('should initiateMotoPurchase() be defined when calling initiateMotoPurchaseTransaction() function', () => {
     // Arrange
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         initiateMotoPurchaseTransaction: jest.fn(),
@@ -58,7 +58,7 @@ describe('Test purchaseHelper()', () => {
 
   test('should setTerminalToIdle() be defined when calling spiSetTerminalToIdle() function', () => {
     // Arrange
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         spiSetTerminalToIdle: jest.fn(),

--- a/src/utils/common/terminal/terminalHelpers.test.ts
+++ b/src/utils/common/terminal/terminalHelpers.test.ts
@@ -8,7 +8,7 @@ describe('Test terminalHelpers()', () => {
 
   test('should settlement() be defined when calling initTxSettlement() function', () => {
     // Arrange
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         InitiateSettleTx: jest.fn(),
@@ -26,7 +26,7 @@ describe('Test terminalHelpers()', () => {
 
   test('should settlementEnquiry() be defined when calling initTxSettlementEnquiry() function', () => {
     // Arrange
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         InitiateSettlementEnquiry: jest.fn(),
@@ -44,7 +44,7 @@ describe('Test terminalHelpers()', () => {
 
   test('should approveSignature() be defined when calling signatureForApprove() function', () => {
     // Arrange
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         AcceptSignature: jest.fn(),
@@ -62,7 +62,7 @@ describe('Test terminalHelpers()', () => {
 
   test('should declineSignature() be defined when calling signatureForDecline() function', () => {
     // Arrange
-    spiService.readTerminalInstance = jest.fn().mockReturnValue({
+    spiService.readSpiInstance = jest.fn().mockReturnValue({
       spiClient: {
         ...mockSpiClient,
         AcceptSignature: jest.fn(),

--- a/src/utils/tests/common.tsx
+++ b/src/utils/tests/common.tsx
@@ -167,6 +167,7 @@ export const defaultMockTerminals = {
     terminalStatus: '',
     txFlow: null,
     txMessage: null, // not available during pair terminal stage
+    posVersion: '',
   },
 };
 


### PR DESCRIPTION
The issue is we store terminal information in redux:persist and self-managed localStorage ( spiService ).  Terminal infor saved in self-managed localStorage is used to initiate SPI library instance, and   the one in redux:persist is used in the terminal page to display to users. We don't have single source of truth,  so when they're mismatch ( the terminal is removed in self-managed localStorage, but haven't removed in redux:persist will cause a crash ). 
